### PR TITLE
Added WAN egress qos fix

### DIFF
--- a/fields/main.go
+++ b/fields/main.go
@@ -258,14 +258,6 @@ func main() {
 				f.OmitEmpty = true
 				return nil
 			}
-		case "NetworkConf":
-			resource.FieldProcessor = func(name string, f *FieldInfo) error {
-				switch name {
-				case "WANEgressQOS":
-					f.FieldType = "string"
-				}
-				return nil
-			}
 		case "SettingUsg":
 			resource.FieldProcessor = func(name string, f *FieldInfo) error {
 				if strings.HasSuffix(name, "Timeout") && name != "ArpCacheTimeout" {

--- a/fields/main.go
+++ b/fields/main.go
@@ -258,6 +258,14 @@ func main() {
 				f.OmitEmpty = true
 				return nil
 			}
+		case "NetworkConf":
+			resource.FieldProcessor = func(name string, f *FieldInfo) error {
+				switch name {
+				case "WANEgressQOS":
+					f.FieldType = "string"
+				}
+				return nil
+			}
 		case "SettingUsg":
 			resource.FieldProcessor = func(name string, f *FieldInfo) error {
 				if strings.HasSuffix(name, "Timeout") && name != "ArpCacheTimeout" {

--- a/unifi/network.go
+++ b/unifi/network.go
@@ -11,6 +11,7 @@ func (dst *Network) UnmarshalJSON(b []byte) error {
 	aux := &struct {
 		VLAN           emptyStringInt `json:"vlan"`
 		DHCPDLeaseTime emptyStringInt `json:"dhcpd_leasetime"`
+		WANEgressQOS   emptyStringInt `json:"wan_egress_qos"`
 
 		*Alias
 	}{
@@ -24,6 +25,7 @@ func (dst *Network) UnmarshalJSON(b []byte) error {
 
 	dst.VLAN = int(aux.VLAN)
 	dst.DHCPDLeaseTime = int(aux.DHCPDLeaseTime)
+	dst.WANEgressQOS = int(aux.WANEgressQOS)
 
 	return nil
 }

--- a/unifi/network_test.go
+++ b/unifi/network_test.go
@@ -38,6 +38,19 @@ func TestNetworkUnmarshalJSON(t *testing.T) {
 			expected: unifi.Network{DHCPDLeaseTime: 0},
 			json:     `{ "dhcpd_leasetime": "" }`,
 		},
+
+		"int wan_egress_qos": {
+			expected: unifi.Network{WANEgressQOS: 1},
+			json:     `{ "wan_egress_qos": 1 }`,
+		},
+		"string wan_egress_qos": {
+			expected: unifi.Network{WANEgressQOS: 1},
+			json:     `{ "wan_egress_qos": "1" }`,
+		},
+		"empty string wan_egress_qos": {
+			expected: unifi.Network{WANEgressQOS: 0},
+			json:     `{ "wan_egress_qos": "" }`,
+		},
 	} {
 		t.Run(n, func(t *testing.T) {
 			var actual unifi.Network


### PR DESCRIPTION
WAN Egress QOS is returned via the Unifi controller API as a string, not an integer. This means that the downloaded JSON files that describe the JSON schema for Network response is incorrect.

I've added a fix that switched the type to string from int when generating the output go code. I've tried to follow the same pattern used for the other fixes that do something similar.

I need this fix as I've implemented some of the WAN Network configuration in terraform-provider-unifi, so I need to get this merged before I can raise my other PR.

Unfortunately I'm using OSX so I wasnt able to actually run the code. If I get a chance, I may raise a follow up PR which moves the generating code into a docker container, to make it easier for contributers.