### PR TITLE
Generate `UnmarshalJSON` to handle `emptyStringInt` types

### DIFF
--- a/fields/api.go.tmpl
+++ b/fields/api.go.tmpl
@@ -2,6 +2,18 @@
 
 {{ define "field" }}
 	{{ .FieldName }} {{ if .IsArray }}[]{{end}}{{ .FieldType }} `json:"{{ .JSONName }}{{ if .OmitEmpty }},omitempty{{ end }}"` {{ if .FieldValidation }}// {{ .FieldValidation }}{{ end }} {{- end }}
+{{ define "field-emptyStringInt" }}
+	{{- if ne .FieldType "int" }}{{else}}
+	    {{ .FieldName }} {{ if .IsArray }}[]{{end}}emptyStringInt `json:"{{ .JSONName }}{{ if .OmitEmpty }}{{ end }}"`{{ end }} {{- end }}
+{{ define "typecast" }}
+    {{- if eq .FieldType "int" }}{{- if .IsArray }}
+    dst.{{ .FieldName }}= make([]int, len(aux.{{ .FieldName }}))
+    for i, v := range aux.{{ .FieldName }} {
+        dst.{{ .FieldName }}[i] = int(v)
+    }
+    {{- else }}
+    dst.{{ .FieldName }} = int(aux.{{ .FieldName }})
+    {{- end }}{{- end }}{{- end }}
 {{ define "field-embed" }}
 	{{ .FieldName }} {{ if .IsArray }}[]{{end}}{{ if not .Fields }}{{ .FieldType }}{{ else }}struct {
 	{{ range $fk, $fv := .Fields }}{{ if not $fv }}
@@ -14,13 +26,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 {{ if embedTypes -}}
@@ -35,6 +49,28 @@ type {{ $k }} struct {
 type {{ $k }} struct {
 	{{ range $fk, $fv := $v.Fields }}{{ if not $fv }}
 	{{ else }}{{- template "field" $fv }}{{ end }}{{ end }}
+}
+
+func (dst *{{ $k }}) UnmarshalJSON(b []byte) error {
+	type Alias {{ $k }}
+	aux := &struct {
+	    {{- range $fk, $fv := $v.Fields }}{{ if not $fv }}
+	    {{- else }}{{- template "field-emptyStringInt" $fv }}{{ end }}{{- end }}
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+    {{- range $fk, $fv := $v.Fields }}{{ if not $fv }}
+    {{- else }}{{- template "typecast" $fv }}{{ end }}{{ end }}
+
+	return nil
 }
 {{ end }}
 {{- end -}}

--- a/unifi/account.go
+++ b/unifi/account.go
@@ -3,32 +3,7 @@ package unifi
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 )
-
-func (dst *Account) UnmarshalJSON(b []byte) error {
-	type Alias Account
-	aux := &struct {
-		TunnelType       emptyStringInt `json:"tunnel_type"`
-		TunnelMediumType emptyStringInt `json:"tunnel_medium_type"`
-		VLAN             emptyStringInt `json:"vlan"`
-
-		*Alias
-	}{
-		Alias: (*Alias)(dst),
-	}
-
-	err := json.Unmarshal(b, &aux)
-	if err != nil {
-		return fmt.Errorf("unable to unmarshal alias: %w", err)
-	}
-
-	dst.TunnelType = int(aux.TunnelType)
-	dst.TunnelMediumType = int(aux.TunnelMediumType)
-	dst.VLAN = int(aux.VLAN)
-
-	return nil
-}
 
 func (dst *Account) MarshalJSON() ([]byte, error) {
 	type Alias Account

--- a/unifi/broadcast_group.generated.go
+++ b/unifi/broadcast_group.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type BroadcastGroup struct {
@@ -25,6 +27,22 @@ type BroadcastGroup struct {
 
 	MemberTable []string `json:"member_table,omitempty"`
 	Name        string   `json:"name,omitempty"`
+}
+
+func (dst *BroadcastGroup) UnmarshalJSON(b []byte) error {
+	type Alias BroadcastGroup
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) listBroadcastGroup(ctx context.Context, site string) ([]BroadcastGroup, error) {

--- a/unifi/channel_plan.generated.go
+++ b/unifi/channel_plan.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type ChannelPlan struct {
@@ -36,16 +38,72 @@ type ChannelPlan struct {
 	SiteBlacklistedChannels []ChannelPlanSiteBlacklistedChannels `json:"site_blacklisted_channels,omitempty"`
 }
 
+func (dst *ChannelPlan) UnmarshalJSON(b []byte) error {
+	type Alias ChannelPlan
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
+}
+
 type ChannelPlanApBlacklistedChannels struct {
 	Channel   int    `json:"channel,omitempty"`   // 36|38|40|42|44|46|48|52|56|60|64|100|104|108|112|116|120|124|128|132|136|140|144|149|153|157|161|165|183|184|185|187|188|189|192|196
 	MAC       string `json:"mac,omitempty"`       // ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
 	Timestamp int    `json:"timestamp,omitempty"` // [1-9][0-9]{12}
 }
 
+func (dst *ChannelPlanApBlacklistedChannels) UnmarshalJSON(b []byte) error {
+	type Alias ChannelPlanApBlacklistedChannels
+	aux := &struct {
+		Channel   emptyStringInt `json:"channel"`
+		Timestamp emptyStringInt `json:"timestamp"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.Channel = int(aux.Channel)
+	dst.Timestamp = int(aux.Timestamp)
+
+	return nil
+}
+
 type ChannelPlanCoupling struct {
 	Rssi   int    `json:"rssi,omitempty"`
 	Source string `json:"source,omitempty"` // ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2}).*$
 	Target string `json:"target,omitempty"` // ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2}).*$
+}
+
+func (dst *ChannelPlanCoupling) UnmarshalJSON(b []byte) error {
+	type Alias ChannelPlanCoupling
+	aux := &struct {
+		Rssi emptyStringInt `json:"rssi"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.Rssi = int(aux.Rssi)
+
+	return nil
 }
 
 type ChannelPlanRadioTable struct {
@@ -58,14 +116,70 @@ type ChannelPlanRadioTable struct {
 	Width         int    `json:"width,omitempty"`          // 20|40|80|160
 }
 
+func (dst *ChannelPlanRadioTable) UnmarshalJSON(b []byte) error {
+	type Alias ChannelPlanRadioTable
+	aux := &struct {
+		Width emptyStringInt `json:"width"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.Width = int(aux.Width)
+
+	return nil
+}
+
 type ChannelPlanSatisfactionTable struct {
 	DeviceMAC    string  `json:"device_mac,omitempty"` // ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
 	Satisfaction float64 `json:"satisfaction,omitempty"`
 }
 
+func (dst *ChannelPlanSatisfactionTable) UnmarshalJSON(b []byte) error {
+	type Alias ChannelPlanSatisfactionTable
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
+}
+
 type ChannelPlanSiteBlacklistedChannels struct {
 	Channel   int `json:"channel,omitempty"`   // 36|38|40|42|44|46|48|52|56|60|64|100|104|108|112|116|120|124|128|132|136|140|144|149|153|157|161|165|183|184|185|187|188|189|192|196
 	Timestamp int `json:"timestamp,omitempty"` // [1-9][0-9]{12}
+}
+
+func (dst *ChannelPlanSiteBlacklistedChannels) UnmarshalJSON(b []byte) error {
+	type Alias ChannelPlanSiteBlacklistedChannels
+	aux := &struct {
+		Channel   emptyStringInt `json:"channel"`
+		Timestamp emptyStringInt `json:"timestamp"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.Channel = int(aux.Channel)
+	dst.Timestamp = int(aux.Timestamp)
+
+	return nil
 }
 
 func (c *Client) listChannelPlan(ctx context.Context, site string) ([]ChannelPlan, error) {

--- a/unifi/dashboard.generated.go
+++ b/unifi/dashboard.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type Dashboard struct {
@@ -30,11 +32,43 @@ type Dashboard struct {
 	Name              string             `json:"name,omitempty"`
 }
 
+func (dst *Dashboard) UnmarshalJSON(b []byte) error {
+	type Alias Dashboard
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
+}
+
 type DashboardModules struct {
 	Config       string `json:"config,omitempty"`
 	ID           string `json:"id"`
 	ModuleID     string `json:"module_id"`
 	Restrictions string `json:"restrictions,omitempty"`
+}
+
+func (dst *DashboardModules) UnmarshalJSON(b []byte) error {
+	type Alias DashboardModules
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) listDashboard(ctx context.Context, site string) ([]Dashboard, error) {

--- a/unifi/dpi_group.generated.go
+++ b/unifi/dpi_group.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type DpiGroup struct {
@@ -26,6 +28,22 @@ type DpiGroup struct {
 	DPIappIDs []string `json:"dpiapp_ids,omitempty"` // [\d\w]+
 	Enabled   bool     `json:"enabled"`
 	Name      string   `json:"name,omitempty"` // .{1,128}
+}
+
+func (dst *DpiGroup) UnmarshalJSON(b []byte) error {
+	type Alias DpiGroup
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) listDpiGroup(ctx context.Context, site string) ([]DpiGroup, error) {

--- a/unifi/dynamic_dns.generated.go
+++ b/unifi/dynamic_dns.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type DynamicDNS struct {
@@ -31,6 +33,22 @@ type DynamicDNS struct {
 	Server        string   `json:"server"`                   // ^[^"' ]+$|^$
 	Service       string   `json:"service,omitempty"`        // afraid|changeip|cloudflare|dnspark|dslreports|dyndns|easydns|googledomains|namecheap|noip|sitelutions|zoneedit|custom
 	XPassword     string   `json:"x_password,omitempty"`     // ^[^"' ]+$
+}
+
+func (dst *DynamicDNS) UnmarshalJSON(b []byte) error {
+	type Alias DynamicDNS
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) listDynamicDNS(ctx context.Context, site string) ([]DynamicDNS, error) {

--- a/unifi/firewall_rule.go
+++ b/unifi/firewall_rule.go
@@ -2,29 +2,7 @@ package unifi
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 )
-
-func (dst *FirewallRule) UnmarshalJSON(b []byte) error {
-	type Alias FirewallRule
-	aux := &struct {
-		RuleIndex emptyStringInt `json:"rule_index"`
-
-		*Alias
-	}{
-		Alias: (*Alias)(dst),
-	}
-
-	err := json.Unmarshal(b, &aux)
-	if err != nil {
-		return fmt.Errorf("unable to unmarshal alias: %w", err)
-	}
-
-	dst.RuleIndex = int(aux.RuleIndex)
-
-	return nil
-}
 
 func (c *Client) ListFirewallRule(ctx context.Context, site string) ([]FirewallRule, error) {
 	return c.listFirewallRule(ctx, site)

--- a/unifi/heat_map.generated.go
+++ b/unifi/heat_map.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type HeatMap struct {
@@ -27,6 +29,22 @@ type HeatMap struct {
 	MapID       string `json:"map_id"`
 	Name        string `json:"name,omitempty"` // .*[^\s]+.*
 	Type        string `json:"type,omitempty"` // download|upload
+}
+
+func (dst *HeatMap) UnmarshalJSON(b []byte) error {
+	type Alias HeatMap
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) listHeatMap(ctx context.Context, site string) ([]HeatMap, error) {

--- a/unifi/heat_map_point.generated.go
+++ b/unifi/heat_map_point.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type HeatMapPoint struct {
@@ -28,6 +30,22 @@ type HeatMapPoint struct {
 	UploadSpeed   float64 `json:"upload_speed,omitempty"`
 	X             float64 `json:"x,omitempty"`
 	Y             float64 `json:"y,omitempty"`
+}
+
+func (dst *HeatMapPoint) UnmarshalJSON(b []byte) error {
+	type Alias HeatMapPoint
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) listHeatMapPoint(ctx context.Context, site string) ([]HeatMapPoint, error) {

--- a/unifi/hotspot_2_conf.generated.go
+++ b/unifi/hotspot_2_conf.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type Hotspot2Conf struct {
@@ -75,10 +77,78 @@ type Hotspot2Conf struct {
 	VenueType               int                                 `json:"venue_type,omitempty"` // 0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15
 }
 
+func (dst *Hotspot2Conf) UnmarshalJSON(b []byte) error {
+	type Alias Hotspot2Conf
+	aux := &struct {
+		AnqpDomainID         emptyStringInt `json:"anqp_domain_id"`
+		DeauthReqTimeout     emptyStringInt `json:"deauth_req_timeout"`
+		GasComebackDelay     emptyStringInt `json:"gas_comeback_delay"`
+		GasFragLimit         emptyStringInt `json:"gas_frag_limit"`
+		IPaddrTypeAvailV4    emptyStringInt `json:"ipaddr_type_avail_v4"`
+		IPaddrTypeAvailV6    emptyStringInt `json:"ipaddr_type_avail_v6"`
+		MetricsDownlinkLoad  emptyStringInt `json:"metrics_downlink_load"`
+		MetricsDownlinkSpeed emptyStringInt `json:"metrics_downlink_speed"`
+		MetricsMeasurement   emptyStringInt `json:"metrics_measurement"`
+		MetricsUplinkLoad    emptyStringInt `json:"metrics_uplink_load"`
+		MetricsUplinkSpeed   emptyStringInt `json:"metrics_uplink_speed"`
+		NetworkAuthType      emptyStringInt `json:"network_auth_type"`
+		NetworkType          emptyStringInt `json:"network_type"`
+		TCTimestamp          emptyStringInt `json:"t_c_timestamp"`
+		VenueGroup           emptyStringInt `json:"venue_group"`
+		VenueType            emptyStringInt `json:"venue_type"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.AnqpDomainID = int(aux.AnqpDomainID)
+	dst.DeauthReqTimeout = int(aux.DeauthReqTimeout)
+	dst.GasComebackDelay = int(aux.GasComebackDelay)
+	dst.GasFragLimit = int(aux.GasFragLimit)
+	dst.IPaddrTypeAvailV4 = int(aux.IPaddrTypeAvailV4)
+	dst.IPaddrTypeAvailV6 = int(aux.IPaddrTypeAvailV6)
+	dst.MetricsDownlinkLoad = int(aux.MetricsDownlinkLoad)
+	dst.MetricsDownlinkSpeed = int(aux.MetricsDownlinkSpeed)
+	dst.MetricsMeasurement = int(aux.MetricsMeasurement)
+	dst.MetricsUplinkLoad = int(aux.MetricsUplinkLoad)
+	dst.MetricsUplinkSpeed = int(aux.MetricsUplinkSpeed)
+	dst.NetworkAuthType = int(aux.NetworkAuthType)
+	dst.NetworkType = int(aux.NetworkType)
+	dst.TCTimestamp = int(aux.TCTimestamp)
+	dst.VenueGroup = int(aux.VenueGroup)
+	dst.VenueType = int(aux.VenueType)
+
+	return nil
+}
+
 type Hotspot2ConfCapab struct {
 	Port     int    `json:"port,omitempty"`     // ^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])|$
 	Protocol string `json:"protocol,omitempty"` // icmp|tcp_udp|tcp|udp|esp
 	Status   string `json:"status,omitempty"`   // closed|open|unknown
+}
+
+func (dst *Hotspot2ConfCapab) UnmarshalJSON(b []byte) error {
+	type Alias Hotspot2ConfCapab
+	aux := &struct {
+		Port emptyStringInt `json:"port"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.Port = int(aux.Port)
+
+	return nil
 }
 
 type Hotspot2ConfCellularNetworkList struct {
@@ -87,9 +157,46 @@ type Hotspot2ConfCellularNetworkList struct {
 	Name string `json:"name,omitempty"` // .{1,128}
 }
 
+func (dst *Hotspot2ConfCellularNetworkList) UnmarshalJSON(b []byte) error {
+	type Alias Hotspot2ConfCellularNetworkList
+	aux := &struct {
+		Mcc emptyStringInt `json:"mcc"`
+		Mnc emptyStringInt `json:"mnc"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.Mcc = int(aux.Mcc)
+	dst.Mnc = int(aux.Mnc)
+
+	return nil
+}
+
 type Hotspot2ConfDescription struct {
 	Language string `json:"language,omitempty"` // [a-z]{3}
 	Text     string `json:"text,omitempty"`     // .{1,128}
+}
+
+func (dst *Hotspot2ConfDescription) UnmarshalJSON(b []byte) error {
+	type Alias Hotspot2ConfDescription
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 type Hotspot2ConfFriendlyName struct {
@@ -97,8 +204,40 @@ type Hotspot2ConfFriendlyName struct {
 	Text     string `json:"text,omitempty"`     // .{1,128}
 }
 
+func (dst *Hotspot2ConfFriendlyName) UnmarshalJSON(b []byte) error {
+	type Alias Hotspot2ConfFriendlyName
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
+}
+
 type Hotspot2ConfIcon struct {
 	Name string `json:"name,omitempty"` // .{1,128}
+}
+
+func (dst *Hotspot2ConfIcon) UnmarshalJSON(b []byte) error {
+	type Alias Hotspot2ConfIcon
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 type Hotspot2ConfIcons struct {
@@ -112,6 +251,29 @@ type Hotspot2ConfIcons struct {
 	Width    int    `json:"width,omitempty"`
 }
 
+func (dst *Hotspot2ConfIcons) UnmarshalJSON(b []byte) error {
+	type Alias Hotspot2ConfIcons
+	aux := &struct {
+		Height emptyStringInt `json:"height"`
+		Size   emptyStringInt `json:"size"`
+		Width  emptyStringInt `json:"width"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.Height = int(aux.Height)
+	dst.Size = int(aux.Size)
+	dst.Width = int(aux.Width)
+
+	return nil
+}
+
 type Hotspot2ConfNaiRealmList struct {
 	AuthIDs   string `json:"auth_ids,omitempty"`
 	AuthVals  string `json:"auth_vals,omitempty"`
@@ -119,6 +281,27 @@ type Hotspot2ConfNaiRealmList struct {
 	Encoding  int    `json:"encoding,omitempty"`   // 0|1
 	Name      string `json:"name,omitempty"`       // .{1,128}
 	Status    bool   `json:"status"`
+}
+
+func (dst *Hotspot2ConfNaiRealmList) UnmarshalJSON(b []byte) error {
+	type Alias Hotspot2ConfNaiRealmList
+	aux := &struct {
+		EapMethod emptyStringInt `json:"eap_method"`
+		Encoding  emptyStringInt `json:"encoding"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.EapMethod = int(aux.EapMethod)
+	dst.Encoding = int(aux.Encoding)
+
+	return nil
 }
 
 type Hotspot2ConfOsu struct {
@@ -133,9 +316,46 @@ type Hotspot2ConfOsu struct {
 	ServerUri        string                     `json:"server_uri,omitempty"`
 }
 
+func (dst *Hotspot2ConfOsu) UnmarshalJSON(b []byte) error {
+	type Alias Hotspot2ConfOsu
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
+}
+
 type Hotspot2ConfQOSMapDcsp struct {
 	High int `json:"high,omitempty"`
 	Low  int `json:"low,omitempty"`
+}
+
+func (dst *Hotspot2ConfQOSMapDcsp) UnmarshalJSON(b []byte) error {
+	type Alias Hotspot2ConfQOSMapDcsp
+	aux := &struct {
+		High emptyStringInt `json:"high"`
+		Low  emptyStringInt `json:"low"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.High = int(aux.High)
+	dst.Low = int(aux.Low)
+
+	return nil
 }
 
 type Hotspot2ConfQOSMapExceptions struct {
@@ -143,15 +363,68 @@ type Hotspot2ConfQOSMapExceptions struct {
 	Up   int `json:"up,omitempty"` // [0-7]
 }
 
+func (dst *Hotspot2ConfQOSMapExceptions) UnmarshalJSON(b []byte) error {
+	type Alias Hotspot2ConfQOSMapExceptions
+	aux := &struct {
+		Dcsp emptyStringInt `json:"dcsp"`
+		Up   emptyStringInt `json:"up"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.Dcsp = int(aux.Dcsp)
+	dst.Up = int(aux.Up)
+
+	return nil
+}
+
 type Hotspot2ConfRoamingConsortiumList struct {
 	Name string `json:"name,omitempty"` // .{1,128}
 	Oid  string `json:"oid,omitempty"`  // .{1,128}
+}
+
+func (dst *Hotspot2ConfRoamingConsortiumList) UnmarshalJSON(b []byte) error {
+	type Alias Hotspot2ConfRoamingConsortiumList
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 type Hotspot2ConfVenueName struct {
 	Language string `json:"language,omitempty"` // [a-z]{3}
 	Name     string `json:"name,omitempty"`
 	Url      string `json:"url,omitempty"`
+}
+
+func (dst *Hotspot2ConfVenueName) UnmarshalJSON(b []byte) error {
+	type Alias Hotspot2ConfVenueName
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) listHotspot2Conf(ctx context.Context, site string) ([]Hotspot2Conf, error) {

--- a/unifi/hotspot_op.generated.go
+++ b/unifi/hotspot_op.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type HotspotOp struct {
@@ -26,6 +28,22 @@ type HotspotOp struct {
 	Name      string `json:"name,omitempty"` // .{1,256}
 	Note      string `json:"note,omitempty"`
 	XPassword string `json:"x_password,omitempty"` // .{1,256}
+}
+
+func (dst *HotspotOp) UnmarshalJSON(b []byte) error {
+	type Alias HotspotOp
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) listHotspotOp(ctx context.Context, site string) ([]HotspotOp, error) {

--- a/unifi/media_file.generated.go
+++ b/unifi/media_file.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type MediaFile struct {
@@ -24,6 +26,22 @@ type MediaFile struct {
 	NoEdit   bool   `json:"attr_no_edit,omitempty"`
 
 	Name string `json:"name,omitempty"`
+}
+
+func (dst *MediaFile) UnmarshalJSON(b []byte) error {
+	type Alias MediaFile
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) listMediaFile(ctx context.Context, site string) ([]MediaFile, error) {

--- a/unifi/network.generated.go
+++ b/unifi/network.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type Network struct {
@@ -166,14 +168,114 @@ type Network struct {
 	XWANPassword            string                          `json:"x_wan_password,omitempty"`              // [^"' ]+
 }
 
+func (dst *Network) UnmarshalJSON(b []byte) error {
+	type Alias Network
+	aux := &struct {
+		DHCPDLeaseTime          emptyStringInt `json:"dhcpd_leasetime"`
+		DHCPDTimeOffset         emptyStringInt `json:"dhcpd_time_offset"`
+		DHCPDV6LeaseTime        emptyStringInt `json:"dhcpdv6_leasetime"`
+		IGMPGroupmembership     emptyStringInt `json:"igmp_groupmembership"`
+		IGMPMaxresponse         emptyStringInt `json:"igmp_maxresponse"`
+		IGMPMcrtrexpiretime     emptyStringInt `json:"igmp_mcrtrexpiretime"`
+		IPSecDhGroup            emptyStringInt `json:"ipsec_dh_group"`
+		IPSecEspDhGroup         emptyStringInt `json:"ipsec_esp_dh_group"`
+		IPSecIkeDhGroup         emptyStringInt `json:"ipsec_ike_dh_group"`
+		IPV6RaPreferredLifetime emptyStringInt `json:"ipv6_ra_preferred_lifetime"`
+		IPV6RaValidLifetime     emptyStringInt `json:"ipv6_ra_valid_lifetime"`
+		OpenVPNLocalPort        emptyStringInt `json:"openvpn_local_port"`
+		OpenVPNRemotePort       emptyStringInt `json:"openvpn_remote_port"`
+		PptpcRouteDistance      emptyStringInt `json:"pptpc_route_distance"`
+		Priority                emptyStringInt `json:"priority"`
+		RouteDistance           emptyStringInt `json:"route_distance"`
+		VLAN                    emptyStringInt `json:"vlan"`
+		WANDHCPv6PDSize         emptyStringInt `json:"wan_dhcpv6_pd_size"`
+		WANEgressQOS            emptyStringInt `json:"wan_egress_qos"`
+		WANLoadBalanceWeight    emptyStringInt `json:"wan_load_balance_weight"`
+		WANPrefixlen            emptyStringInt `json:"wan_prefixlen"`
+		WANSmartqDownRate       emptyStringInt `json:"wan_smartq_down_rate"`
+		WANSmartqUpRate         emptyStringInt `json:"wan_smartq_up_rate"`
+		WANVLAN                 emptyStringInt `json:"wan_vlan"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.DHCPDLeaseTime = int(aux.DHCPDLeaseTime)
+	dst.DHCPDTimeOffset = int(aux.DHCPDTimeOffset)
+	dst.DHCPDV6LeaseTime = int(aux.DHCPDV6LeaseTime)
+	dst.IGMPGroupmembership = int(aux.IGMPGroupmembership)
+	dst.IGMPMaxresponse = int(aux.IGMPMaxresponse)
+	dst.IGMPMcrtrexpiretime = int(aux.IGMPMcrtrexpiretime)
+	dst.IPSecDhGroup = int(aux.IPSecDhGroup)
+	dst.IPSecEspDhGroup = int(aux.IPSecEspDhGroup)
+	dst.IPSecIkeDhGroup = int(aux.IPSecIkeDhGroup)
+	dst.IPV6RaPreferredLifetime = int(aux.IPV6RaPreferredLifetime)
+	dst.IPV6RaValidLifetime = int(aux.IPV6RaValidLifetime)
+	dst.OpenVPNLocalPort = int(aux.OpenVPNLocalPort)
+	dst.OpenVPNRemotePort = int(aux.OpenVPNRemotePort)
+	dst.PptpcRouteDistance = int(aux.PptpcRouteDistance)
+	dst.Priority = int(aux.Priority)
+	dst.RouteDistance = int(aux.RouteDistance)
+	dst.VLAN = int(aux.VLAN)
+	dst.WANDHCPv6PDSize = int(aux.WANDHCPv6PDSize)
+	dst.WANEgressQOS = int(aux.WANEgressQOS)
+	dst.WANLoadBalanceWeight = int(aux.WANLoadBalanceWeight)
+	dst.WANPrefixlen = int(aux.WANPrefixlen)
+	dst.WANSmartqDownRate = int(aux.WANSmartqDownRate)
+	dst.WANSmartqUpRate = int(aux.WANSmartqUpRate)
+	dst.WANVLAN = int(aux.WANVLAN)
+
+	return nil
+}
+
 type NetworkNATOutboundIPAddresses struct {
 	IPAddress       string `json:"ip_address"`                  // ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$|^$
 	WANNetworkGroup string `json:"wan_network_group,omitempty"` // WAN|WAN2
 }
 
+func (dst *NetworkNATOutboundIPAddresses) UnmarshalJSON(b []byte) error {
+	type Alias NetworkNATOutboundIPAddresses
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
+}
+
 type NetworkWANDHCPOptions struct {
 	OptionNumber int    `json:"optionNumber,omitempty"` // ([1-9]|[1-8][0-9]|9[0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-4])
 	Value        string `json:"value,omitempty"`
+}
+
+func (dst *NetworkWANDHCPOptions) UnmarshalJSON(b []byte) error {
+	type Alias NetworkWANDHCPOptions
+	aux := &struct {
+		OptionNumber emptyStringInt `json:"optionNumber"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.OptionNumber = int(aux.OptionNumber)
+
+	return nil
 }
 
 func (c *Client) listNetwork(ctx context.Context, site string) ([]Network, error) {

--- a/unifi/network.go
+++ b/unifi/network.go
@@ -2,33 +2,8 @@ package unifi
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 )
-
-func (dst *Network) UnmarshalJSON(b []byte) error {
-	type Alias Network
-	aux := &struct {
-		VLAN           emptyStringInt `json:"vlan"`
-		DHCPDLeaseTime emptyStringInt `json:"dhcpd_leasetime"`
-		WANEgressQOS   emptyStringInt `json:"wan_egress_qos"`
-
-		*Alias
-	}{
-		Alias: (*Alias)(dst),
-	}
-
-	err := json.Unmarshal(b, &aux)
-	if err != nil {
-		return fmt.Errorf("unable to unmarshal alias: %w", err)
-	}
-
-	dst.VLAN = int(aux.VLAN)
-	dst.DHCPDLeaseTime = int(aux.DHCPDLeaseTime)
-	dst.WANEgressQOS = int(aux.WANEgressQOS)
-
-	return nil
-}
 
 func (c *Client) DeleteNetwork(ctx context.Context, site, id, name string) error {
 	err := c.do(ctx, "DELETE", fmt.Sprintf("s/%s/rest/networkconf/%s", site, id), struct {

--- a/unifi/network_test.go
+++ b/unifi/network_test.go
@@ -51,6 +51,19 @@ func TestNetworkUnmarshalJSON(t *testing.T) {
 			expected: unifi.Network{WANEgressQOS: 0},
 			json:     `{ "wan_egress_qos": "" }`,
 		},
+
+		"int wan_vlan": {
+			expected: unifi.Network{WANVLAN: 1},
+			json:     `{ "wan_vlan": 1 }`,
+		},
+		"string wan_vlan": {
+			expected: unifi.Network{WANVLAN: 1},
+			json:     `{ "wan_vlan": "1" }`,
+		},
+		"empty wan_vlan vlan": {
+			expected: unifi.Network{WANVLAN: 0},
+			json:     `{ "wan_vlan": "" }`,
+		},
 	} {
 		t.Run(n, func(t *testing.T) {
 			var actual unifi.Network

--- a/unifi/port_profile.generated.go
+++ b/unifi/port_profile.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type PortProfile struct {
@@ -57,6 +59,49 @@ type PortProfile struct {
 	StpPortMode                  bool     `json:"stp_port_mode"`
 	TaggedNetworkIDs             []string `json:"tagged_networkconf_ids,omitempty"`
 	VoiceNetworkID               string   `json:"voice_networkconf_id"`
+}
+
+func (dst *PortProfile) UnmarshalJSON(b []byte) error {
+	type Alias PortProfile
+	aux := &struct {
+		Dot1XIDleTimeout           emptyStringInt `json:"dot1x_idle_timeout"`
+		EgressRateLimitKbps        emptyStringInt `json:"egress_rate_limit_kbps"`
+		PriorityQueue1Level        emptyStringInt `json:"priority_queue1_level"`
+		PriorityQueue2Level        emptyStringInt `json:"priority_queue2_level"`
+		PriorityQueue3Level        emptyStringInt `json:"priority_queue3_level"`
+		PriorityQueue4Level        emptyStringInt `json:"priority_queue4_level"`
+		Speed                      emptyStringInt `json:"speed"`
+		StormctrlBroadcastastLevel emptyStringInt `json:"stormctrl_bcast_level"`
+		StormctrlBroadcastastRate  emptyStringInt `json:"stormctrl_bcast_rate"`
+		StormctrlMcastLevel        emptyStringInt `json:"stormctrl_mcast_level"`
+		StormctrlMcastRate         emptyStringInt `json:"stormctrl_mcast_rate"`
+		StormctrlUcastLevel        emptyStringInt `json:"stormctrl_ucast_level"`
+		StormctrlUcastRate         emptyStringInt `json:"stormctrl_ucast_rate"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.Dot1XIDleTimeout = int(aux.Dot1XIDleTimeout)
+	dst.EgressRateLimitKbps = int(aux.EgressRateLimitKbps)
+	dst.PriorityQueue1Level = int(aux.PriorityQueue1Level)
+	dst.PriorityQueue2Level = int(aux.PriorityQueue2Level)
+	dst.PriorityQueue3Level = int(aux.PriorityQueue3Level)
+	dst.PriorityQueue4Level = int(aux.PriorityQueue4Level)
+	dst.Speed = int(aux.Speed)
+	dst.StormctrlBroadcastastLevel = int(aux.StormctrlBroadcastastLevel)
+	dst.StormctrlBroadcastastRate = int(aux.StormctrlBroadcastastRate)
+	dst.StormctrlMcastLevel = int(aux.StormctrlMcastLevel)
+	dst.StormctrlMcastRate = int(aux.StormctrlMcastRate)
+	dst.StormctrlUcastLevel = int(aux.StormctrlUcastLevel)
+	dst.StormctrlUcastRate = int(aux.StormctrlUcastRate)
+
+	return nil
 }
 
 func (c *Client) listPortProfile(ctx context.Context, site string) ([]PortProfile, error) {

--- a/unifi/radius_profile.generated.go
+++ b/unifi/radius_profile.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type RADIUSProfile struct {
@@ -35,16 +37,73 @@ type RADIUSProfile struct {
 	VLANWLANMode          string                     `json:"vlan_wlan_mode,omitempty"` // disabled|optional|required
 }
 
+func (dst *RADIUSProfile) UnmarshalJSON(b []byte) error {
+	type Alias RADIUSProfile
+	aux := &struct {
+		InterimUpdateInterval emptyStringInt `json:"interim_update_interval"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.InterimUpdateInterval = int(aux.InterimUpdateInterval)
+
+	return nil
+}
+
 type RADIUSProfileAcctServers struct {
 	IP      string `json:"ip,omitempty"`   // ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
 	Port    int    `json:"port,omitempty"` // ^([1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-4][0-9]{3}|[6][5][0-4][0-9]{2}|[6][5][5][0-2][0-9]|[6][5][5][3][0-5])$|^$
 	XSecret string `json:"x_secret,omitempty"`
 }
 
+func (dst *RADIUSProfileAcctServers) UnmarshalJSON(b []byte) error {
+	type Alias RADIUSProfileAcctServers
+	aux := &struct {
+		Port emptyStringInt `json:"port"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.Port = int(aux.Port)
+
+	return nil
+}
+
 type RADIUSProfileAuthServers struct {
 	IP      string `json:"ip,omitempty"`   // ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
 	Port    int    `json:"port,omitempty"` // ^([1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-4][0-9]{3}|[6][5][0-4][0-9]{2}|[6][5][5][0-2][0-9]|[6][5][5][3][0-5])$|^$
 	XSecret string `json:"x_secret,omitempty"`
+}
+
+func (dst *RADIUSProfileAuthServers) UnmarshalJSON(b []byte) error {
+	type Alias RADIUSProfileAuthServers
+	aux := &struct {
+		Port emptyStringInt `json:"port"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.Port = int(aux.Port)
+
+	return nil
 }
 
 func (c *Client) listRADIUSProfile(ctx context.Context, site string) ([]RADIUSProfile, error) {

--- a/unifi/routing.generated.go
+++ b/unifi/routing.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type Routing struct {
@@ -31,6 +33,25 @@ type Routing struct {
 	StaticRouteNexthop   string `json:"static-route_nexthop"`            // ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([1-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$|^([a-fA-F0-9:]+)$|^$
 	StaticRouteType      string `json:"static-route_type,omitempty"`     // nexthop-route|interface-route|blackhole
 	Type                 string `json:"type,omitempty"`                  // static-route
+}
+
+func (dst *Routing) UnmarshalJSON(b []byte) error {
+	type Alias Routing
+	aux := &struct {
+		StaticRouteDistance emptyStringInt `json:"static-route_distance"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.StaticRouteDistance = int(aux.StaticRouteDistance)
+
+	return nil
 }
 
 func (c *Client) listRouting(ctx context.Context, site string) ([]Routing, error) {

--- a/unifi/schedule_task.generated.go
+++ b/unifi/schedule_task.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type ScheduleTask struct {
@@ -35,8 +37,40 @@ type ScheduleTask struct {
 	UpgradeTargets          []ScheduleTaskUpgradeTargets `json:"upgrade_targets,omitempty"`
 }
 
+func (dst *ScheduleTask) UnmarshalJSON(b []byte) error {
+	type Alias ScheduleTask
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
+}
+
 type ScheduleTaskUpgradeTargets struct {
 	MAC string `json:"mac,omitempty"` // ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
+}
+
+func (dst *ScheduleTaskUpgradeTargets) UnmarshalJSON(b []byte) error {
+	type Alias ScheduleTaskUpgradeTargets
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) listScheduleTask(ctx context.Context, site string) ([]ScheduleTask, error) {

--- a/unifi/setting_baresip.generated.go
+++ b/unifi/setting_baresip.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingBaresip struct {
@@ -29,6 +31,22 @@ type SettingBaresip struct {
 	OutboundProxy string `json:"outbound_proxy,omitempty"`
 	PackageUrl    string `json:"package_url,omitempty"`
 	Server        string `json:"server,omitempty"`
+}
+
+func (dst *SettingBaresip) UnmarshalJSON(b []byte) error {
+	type Alias SettingBaresip
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) getSettingBaresip(ctx context.Context, site string) (*SettingBaresip, error) {

--- a/unifi/setting_broadcast.generated.go
+++ b/unifi/setting_broadcast.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingBroadcast struct {
@@ -31,6 +33,22 @@ type SettingBroadcast struct {
 	SoundBeforeEnabled  bool   `json:"sound_before_enabled"`
 	SoundBeforeResource string `json:"sound_before_resource,omitempty"`
 	SoundBeforeType     string `json:"sound_before_type,omitempty"` // sample|media
+}
+
+func (dst *SettingBroadcast) UnmarshalJSON(b []byte) error {
+	type Alias SettingBroadcast
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) getSettingBroadcast(ctx context.Context, site string) (*SettingBroadcast, error) {

--- a/unifi/setting_connectivity.generated.go
+++ b/unifi/setting_connectivity.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingConnectivity struct {
@@ -31,6 +33,22 @@ type SettingConnectivity struct {
 	UplinkType         string `json:"uplink_type,omitempty"`
 	XMeshEssid         string `json:"x_mesh_essid,omitempty"`
 	XMeshPsk           string `json:"x_mesh_psk,omitempty"`
+}
+
+func (dst *SettingConnectivity) UnmarshalJSON(b []byte) error {
+	type Alias SettingConnectivity
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) getSettingConnectivity(ctx context.Context, site string) (*SettingConnectivity, error) {

--- a/unifi/setting_dpi.generated.go
+++ b/unifi/setting_dpi.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingDpi struct {
@@ -27,6 +29,22 @@ type SettingDpi struct {
 
 	Enabled               bool `json:"enabled"`
 	FingerprintingEnabled bool `json:"fingerprintingEnabled"`
+}
+
+func (dst *SettingDpi) UnmarshalJSON(b []byte) error {
+	type Alias SettingDpi
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) getSettingDpi(ctx context.Context, site string) (*SettingDpi, error) {

--- a/unifi/setting_element_adopt.generated.go
+++ b/unifi/setting_element_adopt.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingElementAdopt struct {
@@ -28,6 +30,22 @@ type SettingElementAdopt struct {
 	Enabled       bool   `json:"enabled"`
 	XElementEssid string `json:"x_element_essid,omitempty"`
 	XElementPsk   string `json:"x_element_psk,omitempty"`
+}
+
+func (dst *SettingElementAdopt) UnmarshalJSON(b []byte) error {
+	type Alias SettingElementAdopt
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) getSettingElementAdopt(ctx context.Context, site string) (*SettingElementAdopt, error) {

--- a/unifi/setting_guest_access.generated.go
+++ b/unifi/setting_guest_access.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingGuestAccess struct {
@@ -114,6 +116,31 @@ type SettingGuestAccess struct {
 	XStripeApiKey                          string   `json:"x_stripe_api_key,omitempty"`
 	XWechatAppSecret                       string   `json:"x_wechat_app_secret,omitempty"`
 	XWechatSecretKey                       string   `json:"x_wechat_secret_key,omitempty"`
+}
+
+func (dst *SettingGuestAccess) UnmarshalJSON(b []byte) error {
+	type Alias SettingGuestAccess
+	aux := &struct {
+		ExpireNumber               emptyStringInt `json:"expire_number"`
+		ExpireUnit                 emptyStringInt `json:"expire_unit"`
+		PortalCustomizedBoxOpacity emptyStringInt `json:"portal_customized_box_opacity"`
+		RADIUSDisconnectPort       emptyStringInt `json:"radius_disconnect_port"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.ExpireNumber = int(aux.ExpireNumber)
+	dst.ExpireUnit = int(aux.ExpireUnit)
+	dst.PortalCustomizedBoxOpacity = int(aux.PortalCustomizedBoxOpacity)
+	dst.RADIUSDisconnectPort = int(aux.RADIUSDisconnectPort)
+
+	return nil
 }
 
 func (c *Client) getSettingGuestAccess(ctx context.Context, site string) (*SettingGuestAccess, error) {

--- a/unifi/setting_ips.generated.go
+++ b/unifi/setting_ips.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingIps struct {
@@ -38,6 +40,22 @@ type SettingIps struct {
 	Suppression         SettingIpsSuppression  `json:"suppression,omitempty"`
 }
 
+func (dst *SettingIps) UnmarshalJSON(b []byte) error {
+	type Alias SettingIps
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
+}
+
 type SettingIpsAlerts struct {
 	Category  string               `json:"category,omitempty"`
 	Gid       int                  `json:"gid,omitempty"`
@@ -45,6 +63,27 @@ type SettingIpsAlerts struct {
 	Signature string               `json:"signature,omitempty"`
 	Tracking  []SettingIpsTracking `json:"tracking,omitempty"`
 	Type      string               `json:"type,omitempty"` // all|track
+}
+
+func (dst *SettingIpsAlerts) UnmarshalJSON(b []byte) error {
+	type Alias SettingIpsAlerts
+	aux := &struct {
+		Gid emptyStringInt `json:"gid"`
+		ID  emptyStringInt `json:"id"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.Gid = int(aux.Gid)
+	dst.ID = int(aux.ID)
+
+	return nil
 }
 
 type SettingIpsDNSFilters struct {
@@ -58,15 +97,63 @@ type SettingIpsDNSFilters struct {
 	Version      string   `json:"version,omitempty"` // v4|v6
 }
 
+func (dst *SettingIpsDNSFilters) UnmarshalJSON(b []byte) error {
+	type Alias SettingIpsDNSFilters
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
+}
+
 type SettingIpsHoneypot struct {
 	IPAddress string `json:"ip_address,omitempty"`
 	NetworkID string `json:"network_id"`
 	Version   string `json:"version,omitempty"` // v4|v6
 }
 
+func (dst *SettingIpsHoneypot) UnmarshalJSON(b []byte) error {
+	type Alias SettingIpsHoneypot
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
+}
+
 type SettingIpsSuppression struct {
 	Alerts    []SettingIpsAlerts    `json:"alerts,omitempty"`
 	Whitelist []SettingIpsWhitelist `json:"whitelist,omitempty"`
+}
+
+func (dst *SettingIpsSuppression) UnmarshalJSON(b []byte) error {
+	type Alias SettingIpsSuppression
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 type SettingIpsTracking struct {
@@ -75,10 +162,42 @@ type SettingIpsTracking struct {
 	Value     string `json:"value,omitempty"`
 }
 
+func (dst *SettingIpsTracking) UnmarshalJSON(b []byte) error {
+	type Alias SettingIpsTracking
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
+}
+
 type SettingIpsWhitelist struct {
 	Direction string `json:"direction,omitempty"` // both|src|dest
 	Mode      string `json:"mode,omitempty"`      // ip|subnet|network
 	Value     string `json:"value,omitempty"`
+}
+
+func (dst *SettingIpsWhitelist) UnmarshalJSON(b []byte) error {
+	type Alias SettingIpsWhitelist
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) getSettingIps(ctx context.Context, site string) (*SettingIps, error) {

--- a/unifi/setting_locale.generated.go
+++ b/unifi/setting_locale.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingLocale struct {
@@ -26,6 +28,22 @@ type SettingLocale struct {
 	Key string `json:"key"`
 
 	Timezone string `json:"timezone,omitempty"`
+}
+
+func (dst *SettingLocale) UnmarshalJSON(b []byte) error {
+	type Alias SettingLocale
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) getSettingLocale(ctx context.Context, site string) (*SettingLocale, error) {

--- a/unifi/setting_mgmt.generated.go
+++ b/unifi/setting_mgmt.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingMgmt struct {
@@ -42,6 +44,22 @@ type SettingMgmt struct {
 	XSshPassword            string   `json:"x_ssh_password,omitempty"` // .{1,128}
 	XSshSha512Passwd        string   `json:"x_ssh_sha512passwd,omitempty"`
 	XSshUsername            string   `json:"x_ssh_username,omitempty"` // ^[_A-Za-z0-9][-_.A-Za-z0-9]{0,29}$
+}
+
+func (dst *SettingMgmt) UnmarshalJSON(b []byte) error {
+	type Alias SettingMgmt
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) getSettingMgmt(ctx context.Context, site string) (*SettingMgmt, error) {

--- a/unifi/setting_network_optimization.generated.go
+++ b/unifi/setting_network_optimization.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingNetworkOptimization struct {
@@ -26,6 +28,22 @@ type SettingNetworkOptimization struct {
 	Key string `json:"key"`
 
 	Enabled bool `json:"enabled"`
+}
+
+func (dst *SettingNetworkOptimization) UnmarshalJSON(b []byte) error {
+	type Alias SettingNetworkOptimization
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) getSettingNetworkOptimization(ctx context.Context, site string) (*SettingNetworkOptimization, error) {

--- a/unifi/setting_ntp.generated.go
+++ b/unifi/setting_ntp.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingNtp struct {
@@ -29,6 +31,22 @@ type SettingNtp struct {
 	NtpServer2 string `json:"ntp_server_2,omitempty"`
 	NtpServer3 string `json:"ntp_server_3,omitempty"`
 	NtpServer4 string `json:"ntp_server_4,omitempty"`
+}
+
+func (dst *SettingNtp) UnmarshalJSON(b []byte) error {
+	type Alias SettingNtp
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) getSettingNtp(ctx context.Context, site string) (*SettingNtp, error) {

--- a/unifi/setting_porta.generated.go
+++ b/unifi/setting_porta.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingPorta struct {
@@ -26,6 +28,22 @@ type SettingPorta struct {
 	Key string `json:"key"`
 
 	Ugw3WAN2Enabled bool `json:"ugw3_wan2_enabled"`
+}
+
+func (dst *SettingPorta) UnmarshalJSON(b []byte) error {
+	type Alias SettingPorta
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) getSettingPorta(ctx context.Context, site string) (*SettingPorta, error) {

--- a/unifi/setting_snmp.generated.go
+++ b/unifi/setting_snmp.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingSnmp struct {
@@ -30,6 +32,22 @@ type SettingSnmp struct {
 	EnabledV3 bool   `json:"enabledV3"`
 	Username  string `json:"username,omitempty"`   // [a-zA-Z0-9_-]{1,30}
 	XPassword string `json:"x_password,omitempty"` // [^'"]{8,32}
+}
+
+func (dst *SettingSnmp) UnmarshalJSON(b []byte) error {
+	type Alias SettingSnmp
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) getSettingSnmp(ctx context.Context, site string) (*SettingSnmp, error) {

--- a/unifi/setting_super_cloudaccess.generated.go
+++ b/unifi/setting_super_cloudaccess.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingSuperCloudaccess struct {
@@ -32,6 +34,22 @@ type SettingSuperCloudaccess struct {
 	XCertificateArn string `json:"x_certificate_arn,omitempty"`
 	XCertificatePem string `json:"x_certificate_pem,omitempty"`
 	XPrivateKey     string `json:"x_private_key,omitempty"`
+}
+
+func (dst *SettingSuperCloudaccess) UnmarshalJSON(b []byte) error {
+	type Alias SettingSuperCloudaccess
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) getSettingSuperCloudaccess(ctx context.Context, site string) (*SettingSuperCloudaccess, error) {

--- a/unifi/setting_super_events.generated.go
+++ b/unifi/setting_super_events.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingSuperEvents struct {
@@ -26,6 +28,22 @@ type SettingSuperEvents struct {
 	Key string `json:"key"`
 
 	Ignored string `json:"_ignored,omitempty"`
+}
+
+func (dst *SettingSuperEvents) UnmarshalJSON(b []byte) error {
+	type Alias SettingSuperEvents
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) getSettingSuperEvents(ctx context.Context, site string) (*SettingSuperEvents, error) {

--- a/unifi/setting_super_fwupdate.generated.go
+++ b/unifi/setting_super_fwupdate.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingSuperFwupdate struct {
@@ -28,6 +30,22 @@ type SettingSuperFwupdate struct {
 	ControllerChannel string `json:"controller_channel,omitempty"` // internal|alpha|beta|release-candidate|release
 	FirmwareChannel   string `json:"firmware_channel,omitempty"`   // internal|alpha|beta|release-candidate|release
 	SsoEnabled        bool   `json:"sso_enabled"`
+}
+
+func (dst *SettingSuperFwupdate) UnmarshalJSON(b []byte) error {
+	type Alias SettingSuperFwupdate
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) getSettingSuperFwupdate(ctx context.Context, site string) (*SettingSuperFwupdate, error) {

--- a/unifi/setting_super_identity.generated.go
+++ b/unifi/setting_super_identity.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingSuperIdentity struct {
@@ -27,6 +29,22 @@ type SettingSuperIdentity struct {
 
 	Hostname string `json:"hostname,omitempty"`
 	Name     string `json:"name,omitempty"`
+}
+
+func (dst *SettingSuperIdentity) UnmarshalJSON(b []byte) error {
+	type Alias SettingSuperIdentity
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) getSettingSuperIdentity(ctx context.Context, site string) (*SettingSuperIdentity, error) {

--- a/unifi/setting_super_mail.generated.go
+++ b/unifi/setting_super_mail.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingSuperMail struct {
@@ -26,6 +28,22 @@ type SettingSuperMail struct {
 	Key string `json:"key"`
 
 	Provider string `json:"provider,omitempty"` // smtp|cloud|disabled
+}
+
+func (dst *SettingSuperMail) UnmarshalJSON(b []byte) error {
+	type Alias SettingSuperMail
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) getSettingSuperMail(ctx context.Context, site string) (*SettingSuperMail, error) {

--- a/unifi/setting_super_mgmt.generated.go
+++ b/unifi/setting_super_mgmt.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingSuperMgmt struct {
@@ -50,7 +52,7 @@ type SettingSuperMgmt struct {
 	ContactInfoState                         string   `json:"contact_info_state,omitempty"`
 	ContactInfoZip                           string   `json:"contact_info_zip,omitempty"`
 	DataRetentionTimeEnabled                 bool     `json:"data_retention_time_enabled"`
-	DataRetentionTimeInHoursFor5minutesScale int      `json:"data_retention_time_in_hours_for_5minutes_scale,omitempty"`
+	DataRetentionTimeInHoursFor5MinutesScale int      `json:"data_retention_time_in_hours_for_5minutes_scale,omitempty"`
 	DataRetentionTimeInHoursForDailyScale    int      `json:"data_retention_time_in_hours_for_daily_scale,omitempty"`
 	DataRetentionTimeInHoursForHourlyScale   int      `json:"data_retention_time_in_hours_for_hourly_scale,omitempty"`
 	DataRetentionTimeInHoursForMonthlyScale  int      `json:"data_retention_time_in_hours_for_monthly_scale,omitempty"`
@@ -70,6 +72,41 @@ type SettingSuperMgmt struct {
 	TimeSeriesPerClientStatsEnabled          bool     `json:"time_series_per_client_stats_enabled"`
 	XSshPassword                             string   `json:"x_ssh_password,omitempty"`
 	XSshUsername                             string   `json:"x_ssh_username,omitempty"`
+}
+
+func (dst *SettingSuperMgmt) UnmarshalJSON(b []byte) error {
+	type Alias SettingSuperMgmt
+	aux := &struct {
+		AutobackupDays                           emptyStringInt `json:"autobackup_days"`
+		AutobackupMaxFiles                       emptyStringInt `json:"autobackup_max_files"`
+		DataRetentionTimeInHoursFor5MinutesScale emptyStringInt `json:"data_retention_time_in_hours_for_5minutes_scale"`
+		DataRetentionTimeInHoursForDailyScale    emptyStringInt `json:"data_retention_time_in_hours_for_daily_scale"`
+		DataRetentionTimeInHoursForHourlyScale   emptyStringInt `json:"data_retention_time_in_hours_for_hourly_scale"`
+		DataRetentionTimeInHoursForMonthlyScale  emptyStringInt `json:"data_retention_time_in_hours_for_monthly_scale"`
+		DataRetentionTimeInHoursForOthers        emptyStringInt `json:"data_retention_time_in_hours_for_others"`
+		MinimumUsableHdSpace                     emptyStringInt `json:"minimum_usable_hd_space"`
+		MinimumUsableSdSpace                     emptyStringInt `json:"minimum_usable_sd_space"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.AutobackupDays = int(aux.AutobackupDays)
+	dst.AutobackupMaxFiles = int(aux.AutobackupMaxFiles)
+	dst.DataRetentionTimeInHoursFor5MinutesScale = int(aux.DataRetentionTimeInHoursFor5MinutesScale)
+	dst.DataRetentionTimeInHoursForDailyScale = int(aux.DataRetentionTimeInHoursForDailyScale)
+	dst.DataRetentionTimeInHoursForHourlyScale = int(aux.DataRetentionTimeInHoursForHourlyScale)
+	dst.DataRetentionTimeInHoursForMonthlyScale = int(aux.DataRetentionTimeInHoursForMonthlyScale)
+	dst.DataRetentionTimeInHoursForOthers = int(aux.DataRetentionTimeInHoursForOthers)
+	dst.MinimumUsableHdSpace = int(aux.MinimumUsableHdSpace)
+	dst.MinimumUsableSdSpace = int(aux.MinimumUsableSdSpace)
+
+	return nil
 }
 
 func (c *Client) getSettingSuperMgmt(ctx context.Context, site string) (*SettingSuperMgmt, error) {

--- a/unifi/setting_super_sdn.generated.go
+++ b/unifi/setting_super_sdn.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingSuperSdn struct {
@@ -35,6 +37,22 @@ type SettingSuperSdn struct {
 	SsoLoginEnabled   string   `json:"sso_login_enabled,omitempty"`
 	UbicUuid          string   `json:"ubic_uuid,omitempty"`
 	XOauthAppSecret   string   `json:"x_oauth_app_secret,omitempty"`
+}
+
+func (dst *SettingSuperSdn) UnmarshalJSON(b []byte) error {
+	type Alias SettingSuperSdn
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) getSettingSuperSdn(ctx context.Context, site string) (*SettingSuperSdn, error) {

--- a/unifi/setting_usg.generated.go
+++ b/unifi/setting_usg.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingUsg struct {
@@ -80,6 +82,57 @@ type SettingUsg struct {
 	UpnpNATPmpEnabled              bool   `json:"upnp_nat_pmp_enabled"`
 	UpnpSecureMode                 bool   `json:"upnp_secure_mode"`
 	UpnpWANInterface               string `json:"upnp_wan_interface,omitempty"` // WAN|WAN2
+}
+
+func (dst *SettingUsg) UnmarshalJSON(b []byte) error {
+	type Alias SettingUsg
+	aux := &struct {
+		ArpCacheBaseReachable emptyStringInt `json:"arp_cache_base_reachable"`
+		DHCPRelayHopCount     emptyStringInt `json:"dhcp_relay_hop_count"`
+		DHCPRelayMaxSize      emptyStringInt `json:"dhcp_relay_max_size"`
+		DHCPRelayPort         emptyStringInt `json:"dhcp_relay_port"`
+		ICMPTimeout           emptyStringInt `json:"icmp_timeout"`
+		MssClampMss           emptyStringInt `json:"mss_clamp_mss"`
+		OtherTimeout          emptyStringInt `json:"other_timeout"`
+		TCPCloseTimeout       emptyStringInt `json:"tcp_close_timeout"`
+		TCPCloseWaitTimeout   emptyStringInt `json:"tcp_close_wait_timeout"`
+		TCPEstablishedTimeout emptyStringInt `json:"tcp_established_timeout"`
+		TCPFinWaitTimeout     emptyStringInt `json:"tcp_fin_wait_timeout"`
+		TCPLastAckTimeout     emptyStringInt `json:"tcp_last_ack_timeout"`
+		TCPSynRecvTimeout     emptyStringInt `json:"tcp_syn_recv_timeout"`
+		TCPSynSentTimeout     emptyStringInt `json:"tcp_syn_sent_timeout"`
+		TCPTimeWaitTimeout    emptyStringInt `json:"tcp_time_wait_timeout"`
+		UDPOtherTimeout       emptyStringInt `json:"udp_other_timeout"`
+		UDPStreamTimeout      emptyStringInt `json:"udp_stream_timeout"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.ArpCacheBaseReachable = int(aux.ArpCacheBaseReachable)
+	dst.DHCPRelayHopCount = int(aux.DHCPRelayHopCount)
+	dst.DHCPRelayMaxSize = int(aux.DHCPRelayMaxSize)
+	dst.DHCPRelayPort = int(aux.DHCPRelayPort)
+	dst.ICMPTimeout = int(aux.ICMPTimeout)
+	dst.MssClampMss = int(aux.MssClampMss)
+	dst.OtherTimeout = int(aux.OtherTimeout)
+	dst.TCPCloseTimeout = int(aux.TCPCloseTimeout)
+	dst.TCPCloseWaitTimeout = int(aux.TCPCloseWaitTimeout)
+	dst.TCPEstablishedTimeout = int(aux.TCPEstablishedTimeout)
+	dst.TCPFinWaitTimeout = int(aux.TCPFinWaitTimeout)
+	dst.TCPLastAckTimeout = int(aux.TCPLastAckTimeout)
+	dst.TCPSynRecvTimeout = int(aux.TCPSynRecvTimeout)
+	dst.TCPSynSentTimeout = int(aux.TCPSynSentTimeout)
+	dst.TCPTimeWaitTimeout = int(aux.TCPTimeWaitTimeout)
+	dst.UDPOtherTimeout = int(aux.UDPOtherTimeout)
+	dst.UDPStreamTimeout = int(aux.UDPStreamTimeout)
+
+	return nil
 }
 
 func (c *Client) getSettingUsg(ctx context.Context, site string) (*SettingUsg, error) {

--- a/unifi/setting_usw.generated.go
+++ b/unifi/setting_usw.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SettingUsw struct {
@@ -26,6 +28,22 @@ type SettingUsw struct {
 	Key string `json:"key"`
 
 	DHCPSnoop bool `json:"dhcp_snoop"`
+}
+
+func (dst *SettingUsw) UnmarshalJSON(b []byte) error {
+	type Alias SettingUsw
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) getSettingUsw(ctx context.Context, site string) (*SettingUsw, error) {

--- a/unifi/spatial_record.generated.go
+++ b/unifi/spatial_record.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type SpatialRecord struct {
@@ -27,15 +29,63 @@ type SpatialRecord struct {
 	Name    string                 `json:"name,omitempty"` // .{1,128}
 }
 
+func (dst *SpatialRecord) UnmarshalJSON(b []byte) error {
+	type Alias SpatialRecord
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
+}
+
 type SpatialRecordDevices struct {
 	MAC      string                `json:"mac,omitempty"` // ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
 	Position SpatialRecordPosition `json:"position,omitempty"`
+}
+
+func (dst *SpatialRecordDevices) UnmarshalJSON(b []byte) error {
+	type Alias SpatialRecordDevices
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 type SpatialRecordPosition struct {
 	X float64 `json:"x,omitempty"` // (^([-]?[\d]+)$)|(^([-]?[\d]+[.]?[\d]+)$)
 	Y float64 `json:"y,omitempty"` // (^([-]?[\d]+)$)|(^([-]?[\d]+[.]?[\d]+)$)
 	Z float64 `json:"z,omitempty"` // (^([-]?[\d]+)$)|(^([-]?[\d]+[.]?[\d]+)$)
+}
+
+func (dst *SpatialRecordPosition) UnmarshalJSON(b []byte) error {
+	type Alias SpatialRecordPosition
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) listSpatialRecord(ctx context.Context, site string) ([]SpatialRecord, error) {

--- a/unifi/tag.generated.go
+++ b/unifi/tag.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type Tag struct {
@@ -25,6 +27,22 @@ type Tag struct {
 
 	MemberTable []string `json:"member_table,omitempty"`
 	Name        string   `json:"name,omitempty"`
+}
+
+func (dst *Tag) UnmarshalJSON(b []byte) error {
+	type Alias Tag
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) listTag(ctx context.Context, site string) ([]Tag, error) {

--- a/unifi/user.generated.go
+++ b/unifi/user.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type User struct {
@@ -35,6 +37,25 @@ type User struct {
 	Note        string `json:"note,omitempty"`
 	UseFixedIP  bool   `json:"use_fixedip"`
 	UserGroupID string `json:"usergroup_id"`
+}
+
+func (dst *User) UnmarshalJSON(b []byte) error {
+	type Alias User
+	aux := &struct {
+		LastSeen emptyStringInt `json:"last_seen"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.LastSeen = int(aux.LastSeen)
+
+	return nil
 }
 
 func (c *Client) listUser(ctx context.Context, site string) ([]User, error) {

--- a/unifi/virtual_device.generated.go
+++ b/unifi/virtual_device.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type VirtualDevice struct {
@@ -29,6 +31,22 @@ type VirtualDevice struct {
 	Type           string  `json:"type,omitempty"` // uap|usg|usw
 	X              string  `json:"x,omitempty"`
 	Y              string  `json:"y,omitempty"`
+}
+
+func (dst *VirtualDevice) UnmarshalJSON(b []byte) error {
+	type Alias VirtualDevice
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) listVirtualDevice(ctx context.Context, site string) ([]VirtualDevice, error) {

--- a/unifi/wlan.generated.go
+++ b/unifi/wlan.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type WLAN struct {
@@ -97,11 +99,75 @@ type WLAN struct {
 	XWEP                      string                     `json:"x_wep,omitempty"`
 }
 
+func (dst *WLAN) UnmarshalJSON(b []byte) error {
+	type Alias WLAN
+	aux := &struct {
+		DTIMNa                  emptyStringInt `json:"dtim_na"`
+		DTIMNg                  emptyStringInt `json:"dtim_ng"`
+		GroupRekey              emptyStringInt `json:"group_rekey"`
+		MinrateNaBeaconRateKbps emptyStringInt `json:"minrate_na_beacon_rate_kbps"`
+		MinrateNaDataRateKbps   emptyStringInt `json:"minrate_na_data_rate_kbps"`
+		MinrateNaMgmtRateKbps   emptyStringInt `json:"minrate_na_mgmt_rate_kbps"`
+		MinrateNgBeaconRateKbps emptyStringInt `json:"minrate_ng_beacon_rate_kbps"`
+		MinrateNgDataRateKbps   emptyStringInt `json:"minrate_ng_data_rate_kbps"`
+		MinrateNgMgmtRateKbps   emptyStringInt `json:"minrate_ng_mgmt_rate_kbps"`
+		RoamClusterID           emptyStringInt `json:"roam_cluster_id"`
+		VLAN                    emptyStringInt `json:"vlan"`
+		WEPIDX                  emptyStringInt `json:"wep_idx"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.DTIMNa = int(aux.DTIMNa)
+	dst.DTIMNg = int(aux.DTIMNg)
+	dst.GroupRekey = int(aux.GroupRekey)
+	dst.MinrateNaBeaconRateKbps = int(aux.MinrateNaBeaconRateKbps)
+	dst.MinrateNaDataRateKbps = int(aux.MinrateNaDataRateKbps)
+	dst.MinrateNaMgmtRateKbps = int(aux.MinrateNaMgmtRateKbps)
+	dst.MinrateNgBeaconRateKbps = int(aux.MinrateNgBeaconRateKbps)
+	dst.MinrateNgDataRateKbps = int(aux.MinrateNgDataRateKbps)
+	dst.MinrateNgMgmtRateKbps = int(aux.MinrateNgMgmtRateKbps)
+	dst.RoamClusterID = int(aux.RoamClusterID)
+	dst.VLAN = int(aux.VLAN)
+	dst.WEPIDX = int(aux.WEPIDX)
+
+	return nil
+}
+
 type WLANScheduleWithDuration struct {
 	DurationMinutes int      `json:"duration_minutes,omitempty"`   // ^[1-9][0-9]*$
 	StartDaysOfWeek []string `json:"start_days_of_week,omitempty"` // ^(sun|mon|tue|wed|thu|fri|sat)$
 	StartHour       int      `json:"start_hour,omitempty"`         // ^(1?[0-9])|(2[0-3])$
 	StartMinute     int      `json:"start_minute,omitempty"`       // ^[0-5]?[0-9]$
+}
+
+func (dst *WLANScheduleWithDuration) UnmarshalJSON(b []byte) error {
+	type Alias WLANScheduleWithDuration
+	aux := &struct {
+		DurationMinutes emptyStringInt `json:"duration_minutes"`
+		StartHour       emptyStringInt `json:"start_hour"`
+		StartMinute     emptyStringInt `json:"start_minute"`
+
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	dst.DurationMinutes = int(aux.DurationMinutes)
+	dst.StartHour = int(aux.StartHour)
+	dst.StartMinute = int(aux.StartMinute)
+
+	return nil
 }
 
 func (c *Client) listWLAN(ctx context.Context, site string) ([]WLAN, error) {

--- a/unifi/wlan.go
+++ b/unifi/wlan.go
@@ -2,27 +2,7 @@ package unifi
 
 import (
 	"context"
-	"encoding/json"
 )
-
-func (n *WLAN) UnmarshalJSON(b []byte) error {
-	type Alias WLAN
-	aux := &struct {
-		VLAN emptyStringInt `json:"vlan"`
-		*Alias
-	}{
-		Alias: (*Alias)(n),
-	}
-
-	err := json.Unmarshal(b, &aux)
-	if err != nil {
-		return err
-	}
-
-	n.VLAN = int(aux.VLAN)
-
-	return nil
-}
 
 func (c *Client) CreateWLAN(ctx context.Context, site string, d *WLAN) (*WLAN, error) {
 	if d.Schedule == nil {

--- a/unifi/wlan_group.generated.go
+++ b/unifi/wlan_group.generated.go
@@ -5,13 +5,15 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
 // just to fix compile issues with the import
 var (
-	_ fmt.Formatter
 	_ context.Context
+	_ fmt.Formatter
+	_ json.Marshaler
 )
 
 type WLANGroup struct {
@@ -24,6 +26,22 @@ type WLANGroup struct {
 	NoEdit   bool   `json:"attr_no_edit,omitempty"`
 
 	Name string `json:"name,omitempty"` // .{1,128}
+}
+
+func (dst *WLANGroup) UnmarshalJSON(b []byte) error {
+	type Alias WLANGroup
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) listWLANGroup(ctx context.Context, site string) ([]WLANGroup, error) {


### PR DESCRIPTION
This commit changes the code generator to generate a `UnmarshalJSON` for each
struct, so that if unmarshalled it properly handles UniFis varying integer values
via the `emptyStringInt` type.

Structs not including a field of `int` type will still have the function generated,
but it will effectively do nothing.

Fixes #18