### PR TITLE
login before checking status

### DIFF
--- a/unifi/unifi.go
+++ b/unifi/unifi.go
@@ -147,12 +147,6 @@ func (c *Client) Login(ctx context.Context, user, pass string) error {
 		} `json:"meta"`
 	}
 
-	err = c.do(ctx, "GET", c.statusPath, nil, &status)
-	if err != nil {
-		return err
-	}
-	c.version = status.Meta.ServerVersion
-
 	err = c.do(ctx, "POST", c.loginPath, &struct {
 		Username string `json:"username"`
 		Password string `json:"password"`
@@ -163,6 +157,12 @@ func (c *Client) Login(ctx context.Context, user, pass string) error {
 	if err != nil {
 		return err
 	}
+
+	err = c.do(ctx, "GET", c.statusPath, nil, &status)
+	if err != nil {
+		return err
+	}
+	c.version = status.Meta.ServerVersion
 
 	return nil
 }


### PR DESCRIPTION
the status endpoint requires auth, at least in my Cloud Key Firmware 2.X (UniFi OS) setup.
Presumably there are benefits to checking status before logging in; in which case I expect this PR will need to be edited.