### PR TITLE
Fix type of `x_ssh_keys`

### DIFF
--- a/fields/main.go
+++ b/fields/main.go
@@ -306,6 +306,24 @@ func main() {
 				f.OmitEmpty = true
 				return nil
 			}
+		case "SettingMgmt":
+			sshKeyField := NewFieldInfo(resource.StructName+"XSshKeys", "x_ssh_keys", "struct", "", false, false)
+			sshKeyField.Fields = map[string]*FieldInfo{
+				"name":        NewFieldInfo("name", "name", "string", "", false, false),
+				"keyType":     NewFieldInfo("keyType", "type", "string", "", false, false),
+				"key":         NewFieldInfo("key", "key", "string", "", false, false),
+				"comment":     NewFieldInfo("comment", "comment", "string", "", false, false),
+				"date":        NewFieldInfo("date", "date", "string", "", false, false),
+				"fingerprint": NewFieldInfo("fingerprint", "fingerprint", "string", "", false, false),
+			}
+			resource.Types[sshKeyField.FieldName] = sshKeyField
+
+			resource.FieldProcessor = func(name string, f *FieldInfo) error {
+				if name == "XSshKeys" {
+					f.FieldType = sshKeyField.FieldName
+				}
+				return nil
+			}
 		case "SettingUsg":
 			resource.FieldProcessor = func(name string, f *FieldInfo) error {
 				if strings.HasSuffix(name, "Timeout") && name != "ArpCacheTimeout" {

--- a/unifi/setting_mgmt.generated.go
+++ b/unifi/setting_mgmt.generated.go
@@ -27,27 +27,52 @@ type SettingMgmt struct {
 
 	Key string `json:"key"`
 
-	AdvancedFeatureEnabled  bool     `json:"advanced_feature_enabled"`
-	AlertEnabled            bool     `json:"alert_enabled"`
-	AutoUpgrade             bool     `json:"auto_upgrade"`
-	BootSound               bool     `json:"boot_sound"`
-	LedEnabled              bool     `json:"led_enabled"`
-	OutdoorModeEnabled      bool     `json:"outdoor_mode_enabled"`
-	UnifiIDpEnabled         bool     `json:"unifi_idp_enabled"`
-	WifimanEnabled          bool     `json:"wifiman_enabled"`
-	XMgmtKey                string   `json:"x_mgmt_key,omitempty"` // [0-9a-f]{32}
-	XSshAuthPasswordEnabled bool     `json:"x_ssh_auth_password_enabled"`
-	XSshBindWildcard        bool     `json:"x_ssh_bind_wildcard"`
-	XSshEnabled             bool     `json:"x_ssh_enabled"`
-	XSshKeys                []string `json:"x_ssh_keys,omitempty"`
-	XSshMd5Passwd           string   `json:"x_ssh_md5passwd,omitempty"`
-	XSshPassword            string   `json:"x_ssh_password,omitempty"` // .{1,128}
-	XSshSha512Passwd        string   `json:"x_ssh_sha512passwd,omitempty"`
-	XSshUsername            string   `json:"x_ssh_username,omitempty"` // ^[_A-Za-z0-9][-_.A-Za-z0-9]{0,29}$
+	AdvancedFeatureEnabled  bool                  `json:"advanced_feature_enabled"`
+	AlertEnabled            bool                  `json:"alert_enabled"`
+	AutoUpgrade             bool                  `json:"auto_upgrade"`
+	BootSound               bool                  `json:"boot_sound"`
+	LedEnabled              bool                  `json:"led_enabled"`
+	OutdoorModeEnabled      bool                  `json:"outdoor_mode_enabled"`
+	UnifiIDpEnabled         bool                  `json:"unifi_idp_enabled"`
+	WifimanEnabled          bool                  `json:"wifiman_enabled"`
+	XMgmtKey                string                `json:"x_mgmt_key,omitempty"` // [0-9a-f]{32}
+	XSshAuthPasswordEnabled bool                  `json:"x_ssh_auth_password_enabled"`
+	XSshBindWildcard        bool                  `json:"x_ssh_bind_wildcard"`
+	XSshEnabled             bool                  `json:"x_ssh_enabled"`
+	XSshKeys                []SettingMgmtXSshKeys `json:"x_ssh_keys,omitempty"`
+	XSshMd5Passwd           string                `json:"x_ssh_md5passwd,omitempty"`
+	XSshPassword            string                `json:"x_ssh_password,omitempty"` // .{1,128}
+	XSshSha512Passwd        string                `json:"x_ssh_sha512passwd,omitempty"`
+	XSshUsername            string                `json:"x_ssh_username,omitempty"` // ^[_A-Za-z0-9][-_.A-Za-z0-9]{0,29}$
 }
 
 func (dst *SettingMgmt) UnmarshalJSON(b []byte) error {
 	type Alias SettingMgmt
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(dst),
+	}
+
+	err := json.Unmarshal(b, &aux)
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+
+	return nil
+}
+
+type SettingMgmtXSshKeys struct {
+	comment     string `json:"comment"`
+	date        string `json:"date"`
+	fingerprint string `json:"fingerprint"`
+	key         string `json:"key"`
+	keyType     string `json:"type"`
+	name        string `json:"name"`
+}
+
+func (dst *SettingMgmtXSshKeys) UnmarshalJSON(b []byte) error {
+	type Alias SettingMgmtXSshKeys
 	aux := &struct {
 		*Alias
 	}{


### PR DESCRIPTION
The `unifi_settings_mgmt` resource fails for me with the following error:

```
Error: unable to decode body: GET s/default/get/setting/mgmt unable to unmarshal alias: json: cannot unmarshal object into Go struct field .x_ssh_keys of type string
```

My `x_ssh_keys` looks like this:

```
[
  {
    "name": "Laptop",
    "type": "ssh-rsa",
    "key": "REDACTED",
    "comment": "REDACTED",
    "date": "2021-02-25T08:26:04Z",
    "fingerprint": "REDACTED"
  }
]
```