### PR TITLE
Mark generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/fields/*/*.json linguist-generated
+*.generated.go linguist-generated


### PR DESCRIPTION
Hide generated files from diffs in the GitHub UI (see https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/customizing-how-changed-files-appear-on-github).