### PR TITLE
Revert "Add controller version to generated files"

### DIFF
--- a/fields/api.go.tmpl
+++ b/fields/api.go.tmpl
@@ -21,7 +21,6 @@
 	{{ else }}{{- template "field-embed" $fv }}{{ end }}{{ end }}
 }{{ end }} `json:"{{ .JSONName }}{{ if .OmitEmpty }},omitempty{{ end }}"` {{ if .FieldValidation }}// {{ .FieldValidation }}{{ end }} {{- end }}
 // Code generated from ace.jar fields *.json files
-// Controller Version {{ .ControllerVersion }}
 // DO NOT EDIT.
 
 package unifi

--- a/fields/main.go
+++ b/fields/main.go
@@ -92,11 +92,10 @@ var fileReps = []replacement{
 var embedTypes bool
 
 type Resource struct {
-	ControllerVersion string
-	StructName        string
-	ResourcePath      string
-	Types             map[string]*FieldInfo
-	FieldProcessor    func(name string, f *FieldInfo) error
+	StructName     string
+	ResourcePath   string
+	Types          map[string]*FieldInfo
+	FieldProcessor func(name string, f *FieldInfo) error
 }
 
 type FieldInfo struct {
@@ -110,11 +109,9 @@ type FieldInfo struct {
 	CustomUnmarshalType string
 }
 
-func NewResource(version string, structName string, resourcePath string) *Resource {
+func NewResource(structName string, resourcePath string) *Resource {
 	baseType := NewFieldInfo(structName, resourcePath, "struct", "", false, false, "")
 	resource := &Resource{
-		ControllerVersion: version,
-
 		StructName:   structName,
 		ResourcePath: resourcePath,
 		Types: map[string]*FieldInfo{
@@ -301,7 +298,7 @@ func main() {
 			continue
 		}
 
-		resource := NewResource(fmt.Sprintf("v%s", unifiVersion), structName, urlPath)
+		resource := NewResource(structName, urlPath)
 
 		switch resource.StructName {
 		case "Account":

--- a/fields/main_test.go
+++ b/fields/main_test.go
@@ -2,9 +2,8 @@ package main
 
 import (
 	"fmt"
-	"testing"
-
 	assert "github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestFieldInfoFromValidation(t *testing.T) {
@@ -146,7 +145,7 @@ func TestResourceTypes(t *testing.T) {
 	}
 
 	t.Run("structural test", func(t *testing.T) {
-		resource := NewResource("v1.1", "Struct", "path")
+		resource := NewResource("Struct", "path")
 		resource.FieldProcessor = expectation.FieldProcessor
 
 		err := resource.processJSON(([]byte)(testData))

--- a/unifi/account.generated.go
+++ b/unifi/account.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/broadcast_group.generated.go
+++ b/unifi/broadcast_group.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/channel_plan.generated.go
+++ b/unifi/channel_plan.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/dashboard.generated.go
+++ b/unifi/dashboard.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/device.generated.go
+++ b/unifi/device.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/dhcp_option.generated.go
+++ b/unifi/dhcp_option.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/dpi_app.generated.go
+++ b/unifi/dpi_app.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/dpi_group.generated.go
+++ b/unifi/dpi_group.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/dynamic_dns.generated.go
+++ b/unifi/dynamic_dns.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/firewall_group.generated.go
+++ b/unifi/firewall_group.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/firewall_rule.generated.go
+++ b/unifi/firewall_rule.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/heat_map.generated.go
+++ b/unifi/heat_map.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/heat_map_point.generated.go
+++ b/unifi/heat_map_point.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/hotspot_2_conf.generated.go
+++ b/unifi/hotspot_2_conf.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/hotspot_op.generated.go
+++ b/unifi/hotspot_op.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/hotspot_package.generated.go
+++ b/unifi/hotspot_package.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/map.generated.go
+++ b/unifi/map.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/media_file.generated.go
+++ b/unifi/media_file.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/network.generated.go
+++ b/unifi/network.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/port_forward.generated.go
+++ b/unifi/port_forward.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/port_profile.generated.go
+++ b/unifi/port_profile.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/radius_profile.generated.go
+++ b/unifi/radius_profile.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/routing.generated.go
+++ b/unifi/routing.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/schedule_task.generated.go
+++ b/unifi/schedule_task.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_auto_speedtest.generated.go
+++ b/unifi/setting_auto_speedtest.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_baresip.generated.go
+++ b/unifi/setting_baresip.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_broadcast.generated.go
+++ b/unifi/setting_broadcast.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_connectivity.generated.go
+++ b/unifi/setting_connectivity.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_country.generated.go
+++ b/unifi/setting_country.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_dpi.generated.go
+++ b/unifi/setting_dpi.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_element_adopt.generated.go
+++ b/unifi/setting_element_adopt.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_guest_access.generated.go
+++ b/unifi/setting_guest_access.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_ips.generated.go
+++ b/unifi/setting_ips.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_lcm.generated.go
+++ b/unifi/setting_lcm.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_locale.generated.go
+++ b/unifi/setting_locale.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_mgmt.generated.go
+++ b/unifi/setting_mgmt.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_network_optimization.generated.go
+++ b/unifi/setting_network_optimization.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_ntp.generated.go
+++ b/unifi/setting_ntp.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_porta.generated.go
+++ b/unifi/setting_porta.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_radio_ai.generated.go
+++ b/unifi/setting_radio_ai.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_radius.generated.go
+++ b/unifi/setting_radius.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_rsyslogd.generated.go
+++ b/unifi/setting_rsyslogd.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_snmp.generated.go
+++ b/unifi/setting_snmp.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_super_cloudaccess.generated.go
+++ b/unifi/setting_super_cloudaccess.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_super_events.generated.go
+++ b/unifi/setting_super_events.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_super_fwupdate.generated.go
+++ b/unifi/setting_super_fwupdate.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_super_identity.generated.go
+++ b/unifi/setting_super_identity.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_super_mail.generated.go
+++ b/unifi/setting_super_mail.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_super_mgmt.generated.go
+++ b/unifi/setting_super_mgmt.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_super_sdn.generated.go
+++ b/unifi/setting_super_sdn.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_super_smtp.generated.go
+++ b/unifi/setting_super_smtp.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_usg.generated.go
+++ b/unifi/setting_usg.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/setting_usw.generated.go
+++ b/unifi/setting_usw.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/spatial_record.generated.go
+++ b/unifi/spatial_record.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/tag.generated.go
+++ b/unifi/tag.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/user.generated.go
+++ b/unifi/user.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/user_group.generated.go
+++ b/unifi/user_group.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/virtual_device.generated.go
+++ b/unifi/virtual_device.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/wlan.generated.go
+++ b/unifi/wlan.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi

--- a/unifi/wlan_group.generated.go
+++ b/unifi/wlan_group.generated.go
@@ -1,5 +1,4 @@
 // Code generated from ace.jar fields *.json files
-// Controller Version v6.4.54
 // DO NOT EDIT.
 
 package unifi


### PR DESCRIPTION
This reverts commit 13d5677bf31c96f79608198705e4739d62de8959. As mentioned on Slack, this makes comparing version changes a bit more difficult and the version is already present in `version.generated.go`.