### PR TITLE
Add back `mdns_enabled`

### DIFF
--- a/fields/main.go
+++ b/fields/main.go
@@ -144,6 +144,11 @@ func NewResource(structName string, resourcePath string) *Resource {
 	case resource.IsSetting():
 		resource.ResourcePath = strcase.ToSnake(strings.TrimPrefix(structName, "Setting"))
 		baseType.Fields[" Key"] = NewFieldInfo("Key", "key", "string", "", false, false, "")
+
+		if resource.StructName == "SettingUsg" {
+			// Removed in v7, retaining for backwards compatibility
+			baseType.Fields["MdnsEnabled"] = NewFieldInfo("MdnsEnabled", "mdns_enabled", "bool", "", true, false, "")
+		}
 	case resource.StructName == "Device":
 		baseType.Fields[" MAC"] = NewFieldInfo("MAC", "mac", "string", "", true, false, "")
 		baseType.Fields["Adopted"] = NewFieldInfo("Adopted", "adopted", "bool", "", false, false, "")

--- a/unifi/setting_usg.generated.go
+++ b/unifi/setting_usg.generated.go
@@ -55,6 +55,7 @@ type SettingUsg struct {
 	H323Module                     bool   `json:"h323_module"`
 	ICMPTimeout                    int    `json:"icmp_timeout,omitempty"`
 	LldpEnableAll                  bool   `json:"lldp_enable_all"`
+	MdnsEnabled                    bool   `json:"mdns_enabled,omitempty"`
 	MssClamp                       string `json:"mss_clamp,omitempty"`     // auto|custom|disabled
 	MssClampMss                    int    `json:"mss_clamp_mss,omitempty"` // [1-9][0-9]{2,3}
 	OffloadAccounting              bool   `json:"offload_accounting"`


### PR DESCRIPTION
`mdns_enabled` was removed in v7. Add it back so that we can support both v6 and v7.