### PR TITLE
Change User time fields to Time objects.

### DIFF
--- a/fields/api.go.tmpl
+++ b/fields/api.go.tmpl
@@ -29,6 +29,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	{{ range $k, $v := .Packages }}"{{ $k }}"
+	{{ end -}}
 )
 
 // just to fix compile issues with the import

--- a/fields/extract.go
+++ b/fields/extract.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/hashicorp/go-version"
+	version "github.com/hashicorp/go-version"
 	"github.com/iancoleman/strcase"
 	"github.com/ulikunitz/xz"
 	"github.com/xor-gate/ar"

--- a/fields/main.go
+++ b/fields/main.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/go-version"
+	version "github.com/hashicorp/go-version"
 	"github.com/iancoleman/strcase"
 )
 
@@ -383,6 +383,12 @@ func main() {
 				switch name {
 				case "Blocked":
 					f.FieldType = "bool"
+				case "DisconnectTimestamp":
+					f.FieldType = "int"
+					f.CustomUnmarshalType = "emptyStringInt"
+				case "FirstSeen":
+					f.FieldType = "int"
+					f.CustomUnmarshalType = "emptyStringInt"
 				case "LastSeen":
 					f.FieldType = "int"
 					f.CustomUnmarshalType = "emptyStringInt"

--- a/fields/main.go
+++ b/fields/main.go
@@ -95,6 +95,7 @@ var embedTypes bool
 type Resource struct {
 	StructName     string
 	ResourcePath   string
+	Packages       map[string]bool
 	Types          map[string]*FieldInfo
 	FieldProcessor func(name string, f *FieldInfo) error
 }
@@ -115,6 +116,7 @@ func NewResource(structName string, resourcePath string) *Resource {
 	resource := &Resource{
 		StructName:   structName,
 		ResourcePath: resourcePath,
+		Packages:     map[string]bool{},
 		Types: map[string]*FieldInfo{
 			structName: baseType,
 		},
@@ -379,19 +381,20 @@ func main() {
 				return nil
 			}
 		case "User":
+			resource.Packages["time"] = true
 			resource.FieldProcessor = func(name string, f *FieldInfo) error {
 				switch name {
 				case "Blocked":
 					f.FieldType = "bool"
 				case "DisconnectTimestamp":
-					f.FieldType = "int"
-					f.CustomUnmarshalType = "emptyStringInt"
+					f.FieldType = "time.Time"
+					f.CustomUnmarshalType = "unixTime"
 				case "FirstSeen":
-					f.FieldType = "int"
-					f.CustomUnmarshalType = "emptyStringInt"
+					f.FieldType = "time.Time"
+					f.CustomUnmarshalType = "unixTime"
 				case "LastSeen":
-					f.FieldType = "int"
-					f.CustomUnmarshalType = "emptyStringInt"
+					f.FieldType = "time.Time"
+					f.CustomUnmarshalType = "unixTime"
 				}
 				return nil
 			}

--- a/fields/main_test.go
+++ b/fields/main_test.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	assert "github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFieldInfoFromValidation(t *testing.T) {

--- a/fields/version.go
+++ b/fields/version.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/hashicorp/go-version"
+	version "github.com/hashicorp/go-version"
 )
 
 var uiDownloadUrl = "https://www.ui.com/download/?platform=unifi"

--- a/fields/version_test.go
+++ b/fields/version_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hashicorp/go-version"
+	version "github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/unifi/json.go
+++ b/unifi/json.go
@@ -3,6 +3,7 @@ package unifi
 import (
 	"strconv"
 	"strings"
+	"time"
 )
 
 // numberOrString handles strings that can also accept JSON numbers.
@@ -65,4 +66,24 @@ func (e *emptyStringInt) MarshalJSON() ([]byte, error) {
 	}
 
 	return []byte(strconv.Itoa(int(*e))), nil
+}
+
+type unixTime time.Time
+
+func (u *unixTime) UnmarshalJSON(b []byte) error {
+	e := new(emptyStringInt)
+	e.UnmarshalJSON(b)
+	if e == nil {
+		return nil
+	}
+	*u = unixTime(time.Unix(int64(*e), 0))
+	return nil
+}
+
+func (u *unixTime) MarshalJSON() ([]byte, error) {
+	if u == nil {
+		return []byte(`""`), nil
+	}
+
+	return []byte(strconv.Itoa(int(time.Time(*u).Unix()))), nil
 }

--- a/unifi/user.generated.go
+++ b/unifi/user.generated.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 // just to fix compile issues with the import
@@ -28,32 +29,32 @@ type User struct {
 	DevIdOverride int    `json:"dev_id_override,omitempty"` // non-generated field
 	IP            string `json:"ip,omitempty"`              // non-generated field
 
-	Blocked             bool   `json:"blocked,omitempty"`
-	DisconnectTimestamp int    `json:"disconnect_timestamp,omitempty"`
-	FirstSeen           int    `json:"first_seen,omitempty"`
-	FixedApEnabled      bool   `json:"fixed_ap_enabled"`
-	FixedApMAC          string `json:"fixed_ap_mac,omitempty"` // ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
-	FixedIP             string `json:"fixed_ip,omitempty"`
-	Hostname            string `json:"hostname,omitempty"`
-	IsGuest             bool   `json:"is_guest"`
-	IsWired             bool   `json:"is_wired"`
-	LastSeen            int    `json:"last_seen,omitempty"`
-	MAC                 string `json:"mac,omitempty"` // ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
-	Name                string `json:"name,omitempty"`
-	NetworkID           string `json:"network_id"`
-	Note                string `json:"note,omitempty"`
-	Noted               bool   `json:"noted"`
-	Oui                 string `json:"oui,omitempty"`
-	UseFixedIP          bool   `json:"use_fixedip"`
-	UserGroupID         string `json:"usergroup_id"`
+	Blocked             bool      `json:"blocked,omitempty"`
+	DisconnectTimestamp time.Time `json:"disconnect_timestamp,omitempty"`
+	FirstSeen           time.Time `json:"first_seen,omitempty"`
+	FixedApEnabled      bool      `json:"fixed_ap_enabled"`
+	FixedApMAC          string    `json:"fixed_ap_mac,omitempty"` // ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
+	FixedIP             string    `json:"fixed_ip,omitempty"`
+	Hostname            string    `json:"hostname,omitempty"`
+	IsGuest             bool      `json:"is_guest"`
+	IsWired             bool      `json:"is_wired"`
+	LastSeen            time.Time `json:"last_seen,omitempty"`
+	MAC                 string    `json:"mac,omitempty"` // ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
+	Name                string    `json:"name,omitempty"`
+	NetworkID           string    `json:"network_id"`
+	Note                string    `json:"note,omitempty"`
+	Noted               bool      `json:"noted"`
+	Oui                 string    `json:"oui,omitempty"`
+	UseFixedIP          bool      `json:"use_fixedip"`
+	UserGroupID         string    `json:"usergroup_id"`
 }
 
 func (dst *User) UnmarshalJSON(b []byte) error {
 	type Alias User
 	aux := &struct {
-		DisconnectTimestamp emptyStringInt `json:"disconnect_timestamp"`
-		FirstSeen           emptyStringInt `json:"first_seen"`
-		LastSeen            emptyStringInt `json:"last_seen"`
+		DisconnectTimestamp unixTime `json:"disconnect_timestamp"`
+		FirstSeen           unixTime `json:"first_seen"`
+		LastSeen            unixTime `json:"last_seen"`
 
 		*Alias
 	}{
@@ -64,9 +65,9 @@ func (dst *User) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return fmt.Errorf("unable to unmarshal alias: %w", err)
 	}
-	dst.DisconnectTimestamp = int(aux.DisconnectTimestamp)
-	dst.FirstSeen = int(aux.FirstSeen)
-	dst.LastSeen = int(aux.LastSeen)
+	dst.DisconnectTimestamp = time.Time(aux.DisconnectTimestamp)
+	dst.FirstSeen = time.Time(aux.FirstSeen)
+	dst.LastSeen = time.Time(aux.LastSeen)
 
 	return nil
 }

--- a/unifi/user.generated.go
+++ b/unifi/user.generated.go
@@ -28,24 +28,32 @@ type User struct {
 	DevIdOverride int    `json:"dev_id_override,omitempty"` // non-generated field
 	IP            string `json:"ip,omitempty"`              // non-generated field
 
-	Blocked        bool   `json:"blocked,omitempty"`
-	FixedApEnabled bool   `json:"fixed_ap_enabled"`
-	FixedApMAC     string `json:"fixed_ap_mac,omitempty"` // ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
-	FixedIP        string `json:"fixed_ip,omitempty"`
-	Hostname       string `json:"hostname,omitempty"`
-	LastSeen       int    `json:"last_seen,omitempty"`
-	MAC            string `json:"mac,omitempty"` // ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
-	Name           string `json:"name,omitempty"`
-	NetworkID      string `json:"network_id"`
-	Note           string `json:"note,omitempty"`
-	UseFixedIP     bool   `json:"use_fixedip"`
-	UserGroupID    string `json:"usergroup_id"`
+	Blocked             bool   `json:"blocked,omitempty"`
+	DisconnectTimestamp int    `json:"disconnect_timestamp,omitempty"`
+	FirstSeen           int    `json:"first_seen,omitempty"`
+	FixedApEnabled      bool   `json:"fixed_ap_enabled"`
+	FixedApMAC          string `json:"fixed_ap_mac,omitempty"` // ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
+	FixedIP             string `json:"fixed_ip,omitempty"`
+	Hostname            string `json:"hostname,omitempty"`
+	IsGuest             bool   `json:"is_guest"`
+	IsWired             bool   `json:"is_wired"`
+	LastSeen            int    `json:"last_seen,omitempty"`
+	MAC                 string `json:"mac,omitempty"` // ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
+	Name                string `json:"name,omitempty"`
+	NetworkID           string `json:"network_id"`
+	Note                string `json:"note,omitempty"`
+	Noted               bool   `json:"noted"`
+	Oui                 string `json:"oui,omitempty"`
+	UseFixedIP          bool   `json:"use_fixedip"`
+	UserGroupID         string `json:"usergroup_id"`
 }
 
 func (dst *User) UnmarshalJSON(b []byte) error {
 	type Alias User
 	aux := &struct {
-		LastSeen emptyStringInt `json:"last_seen"`
+		DisconnectTimestamp emptyStringInt `json:"disconnect_timestamp"`
+		FirstSeen           emptyStringInt `json:"first_seen"`
+		LastSeen            emptyStringInt `json:"last_seen"`
 
 		*Alias
 	}{
@@ -56,6 +64,8 @@ func (dst *User) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return fmt.Errorf("unable to unmarshal alias: %w", err)
 	}
+	dst.DisconnectTimestamp = int(aux.DisconnectTimestamp)
+	dst.FirstSeen = int(aux.FirstSeen)
 	dst.LastSeen = int(aux.LastSeen)
 
 	return nil


### PR DESCRIPTION
Adds in missing `FirstSeen` and `DisconnectedTimestamp` fields and treats them as `time.Time` objects instead of `int` values.