### PR TITLE
Fix type of `lte_ext_ant`/`lte_poe` fields

### DIFF
--- a/fields/main.go
+++ b/fields/main.go
@@ -339,6 +339,8 @@ func main() {
 					if f.FieldType == "string" {
 						f.CustomUnmarshalType = "numberOrString"
 					}
+				case "LteExtAnt", "LtePoe":
+					f.CustomUnmarshalType = "booleanishString"
 				}
 
 				f.OmitEmpty = true

--- a/unifi/device.generated.go
+++ b/unifi/device.generated.go
@@ -101,13 +101,15 @@ type Device struct {
 func (dst *Device) UnmarshalJSON(b []byte) error {
 	type Alias Device
 	aux := &struct {
-		LcmBrightness              emptyStringInt `json:"lcm_brightness"`
-		LcmIDleTimeout             emptyStringInt `json:"lcm_idle_timeout"`
-		LedOverrideColorBrightness emptyStringInt `json:"led_override_color_brightness"`
-		LteHardLimit               emptyStringInt `json:"lte_hard_limit"`
-		LteSimPin                  emptyStringInt `json:"lte_sim_pin"`
-		LteSoftLimit               emptyStringInt `json:"lte_soft_limit"`
-		Volume                     emptyStringInt `json:"volume"`
+		LcmBrightness              emptyStringInt   `json:"lcm_brightness"`
+		LcmIDleTimeout             emptyStringInt   `json:"lcm_idle_timeout"`
+		LedOverrideColorBrightness emptyStringInt   `json:"led_override_color_brightness"`
+		LteExtAnt                  booleanishString `json:"lte_ext_ant"`
+		LteHardLimit               emptyStringInt   `json:"lte_hard_limit"`
+		LtePoe                     booleanishString `json:"lte_poe"`
+		LteSimPin                  emptyStringInt   `json:"lte_sim_pin"`
+		LteSoftLimit               emptyStringInt   `json:"lte_soft_limit"`
+		Volume                     emptyStringInt   `json:"volume"`
 
 		*Alias
 	}{
@@ -121,7 +123,9 @@ func (dst *Device) UnmarshalJSON(b []byte) error {
 	dst.LcmBrightness = int(aux.LcmBrightness)
 	dst.LcmIDleTimeout = int(aux.LcmIDleTimeout)
 	dst.LedOverrideColorBrightness = int(aux.LedOverrideColorBrightness)
+	dst.LteExtAnt = bool(aux.LteExtAnt)
 	dst.LteHardLimit = int(aux.LteHardLimit)
+	dst.LtePoe = bool(aux.LtePoe)
 	dst.LteSimPin = int(aux.LteSimPin)
 	dst.LteSoftLimit = int(aux.LteSoftLimit)
 	dst.Volume = int(aux.Volume)

--- a/unifi/json.go
+++ b/unifi/json.go
@@ -1,6 +1,7 @@
 package unifi
 
 import (
+	"errors"
 	"strconv"
 	"strings"
 )
@@ -65,4 +66,25 @@ func (e *emptyStringInt) MarshalJSON() ([]byte, error) {
 	}
 
 	return []byte(strconv.Itoa(int(*e))), nil
+}
+
+type booleanishString bool
+
+func (e *booleanishString) UnmarshalJSON(b []byte) error {
+	s := string(b)
+	if s == `"enabled"` {
+		*e = booleanishString(true)
+		return nil
+	} else if s == `"disabled"` {
+		*e = booleanishString(false)
+		return nil
+	}
+	return errors.New("Could not unmarshal JSON value.")
+}
+
+func (e *booleanishString) MarshalJSON(b []byte) ([]byte, error) {
+	if *e == true {
+		return []byte(`"enabled"`), nil
+	}
+	return []byte(`"disabled"`), nil
 }


### PR DESCRIPTION
This fixes https://github.com/paultyng/go-unifi/issues/88 [for me™].

Note that I'm still on v6 currently, but I checked the field definition for my version as well, it did not change since then. I decided to implement a new type instead of fixing the field value to string since it makes more sense in the context and aligns with the API definition.

Feel free to suggest changes or decline :) Thanks again for your hard work.