### PR TITLE
Support firewall reorder command

### DIFF
--- a/unifi/firewall_rule.go
+++ b/unifi/firewall_rule.go
@@ -2,7 +2,13 @@ package unifi
 
 import (
 	"context"
+	"fmt"
 )
+
+type FirewallRuleIndexUpdate struct {
+	ID        string `json:"_id"`
+	RuleIndex int    `json:"rule_index,string"`
+}
 
 func (c *Client) ListFirewallRule(ctx context.Context, site string) ([]FirewallRule, error) {
 	return c.listFirewallRule(ctx, site)
@@ -22,4 +28,22 @@ func (c *Client) CreateFirewallRule(ctx context.Context, site string, d *Firewal
 
 func (c *Client) UpdateFirewallRule(ctx context.Context, site string, d *FirewallRule) (*FirewallRule, error) {
 	return c.updateFirewallRule(ctx, site, d)
+}
+
+func (c *Client) ReorderFirewallRules(ctx context.Context, site, ruleset string, reorder []FirewallRuleIndexUpdate) error {
+	reqBody := struct {
+		Cmd     string                    `json:"cmd"`
+		Ruleset string                    `json:"ruleset"`
+		Rules   []FirewallRuleIndexUpdate `json:"rules"`
+	}{
+		Cmd:     "reorder",
+		Ruleset: ruleset,
+		Rules:   reorder,
+	}
+	err := c.do(ctx, "POST", fmt.Sprintf("s/%s/cmd/firewall", site), reqBody, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
Managing firewall rule indices is a manual process at the moment. I would like the terraform provider to be able to do that automatically, see https://github.com/paultyng/terraform-provider-unifi/issues/361 .

This is commit makes the client support the `reorder` command.