### PR TITLE
Add Error.Is interface method on the custom error type APIError.

### DIFF
--- a/unifi/unifi.go
+++ b/unifi/unifi.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -42,6 +43,16 @@ type APIError struct {
 
 func (err *APIError) Error() string {
 	return err.Message
+}
+
+func (err *APIError) Is(target error) bool {
+	var apiError *APIError
+	if errors.As(target, &apiError) {
+		if err.RC == apiError.RC && err.Message == apiError.Message {
+			return true
+		}
+	}
+	return false
 }
 
 type Client struct {


### PR DESCRIPTION
This method supports doing "errors.Is" checks so downstream can handle API errors more specifically.

In my case, since I copied your lazyClient example, but I'm using it in a server, the Login needs to be refreshed if an API call errors out with "api.err.LoginRequired". There was no clean way to check for this specific error in order to refresh the login and retry.